### PR TITLE
Add error handling when receiving a message from sqs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steveo",
-  "version": "5.0.0-beta7",
+  "version": "5.0.0-beta8",
   "description": "A Task Pub/Sub Background processing library",
   "main": "lib/index.js",
   "author": "engineering@ordermentum.com",

--- a/src/runner/kafka.ts
+++ b/src/runner/kafka.ts
@@ -156,6 +156,7 @@ class KafkaRunner extends BaseRunner
   /**
    *
    * @description It's a bound function to avoid binding when passing as callback to the checker function
+   * Reference: https://github.com/Blizzard/node-rdkafka/issues/217#issuecomment-313582908
    */
   healthCheck = async function() {
     return new Promise<void>((resolve, reject) => {

--- a/src/runner/sqs.ts
+++ b/src/runner/sqs.ts
@@ -160,9 +160,14 @@ class SqsRunner extends BaseRunner implements IRunner {
   }
 
   async dequeue(topic: string, params: SQS.ReceiveMessageRequest) {
-    const data = await this.sqs.receiveMessage(params).promise();
+    const data = await this.sqs.receiveMessage(params)
+      .promise()
+      .catch(e => { 
+        this.logger.error('Error while receiving message from queue', e);
+        return null;
+      });
 
-    if (data.Messages) {
+    if (data?.Messages) {
       this.logger.debug('Message from sqs', data);
       try {
         await this.receive(data.Messages, topic);
@@ -217,7 +222,7 @@ class SqsRunner extends BaseRunner implements IRunner {
     loop();
   }
 
-  healthCheck = async function() {
+  healthCheck = async function () {
     // get a random registered queue
     const items = this.registry.getTopics();
     const item = items[Math.floor(Math.random() * items.length)];
@@ -266,7 +271,7 @@ class SqsRunner extends BaseRunner implements IRunner {
     if (this.currentTimeout) clearTimeout(this.currentTimeout);
   }
 
-  async reconnect() {}
+  async reconnect() { }
 }
 
 export default SqsRunner;

--- a/src/runner/sqs.ts
+++ b/src/runner/sqs.ts
@@ -160,9 +160,10 @@ class SqsRunner extends BaseRunner implements IRunner {
   }
 
   async dequeue(topic: string, params: SQS.ReceiveMessageRequest) {
-    const data = await this.sqs.receiveMessage(params)
+    const data = await this.sqs
+      .receiveMessage(params)
       .promise()
-      .catch(e => { 
+      .catch(e => {
         this.logger.error('Error while receiving message from queue', e);
         return null;
       });
@@ -222,7 +223,7 @@ class SqsRunner extends BaseRunner implements IRunner {
     loop();
   }
 
-  healthCheck = async function () {
+  healthCheck = async function() {
     // get a random registered queue
     const items = this.registry.getTopics();
     const item = items[Math.floor(Math.random() * items.length)];
@@ -271,7 +272,7 @@ class SqsRunner extends BaseRunner implements IRunner {
     if (this.currentTimeout) clearTimeout(this.currentTimeout);
   }
 
-  async reconnect() { }
+  async reconnect() {}
 }
 
 export default SqsRunner;


### PR DESCRIPTION
Receiving message in the sqs runner is an unguarded promise that can break the loop and stop processing. 

This PR adds a catch on that promise and doesn't let the error bubble up to the main process.