### PR TITLE
Fix resuming of kafka consumers

### DIFF
--- a/packages/steveo/package.json
+++ b/packages/steveo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steveo",
-  "version": "6.0.0-beta7",
+  "version": "6.0.0-beta8",
   "description": "A Task Pub/Sub Background processing library",
   "main": "lib/index.js",
   "author": "engineering@ordermentum.com",

--- a/packages/steveo/package.json
+++ b/packages/steveo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steveo",
-  "version": "6.0.0-beta6",
+  "version": "6.0.0-beta7",
   "description": "A Task Pub/Sub Background processing library",
   "main": "lib/index.js",
   "author": "engineering@ordermentum.com",

--- a/packages/steveo/src/consumers/kafka.ts
+++ b/packages/steveo/src/consumers/kafka.ts
@@ -185,7 +185,7 @@ class KafkaRunner
       this.disconnect();
       return;
     }
-    
+
     if (this.state === 'paused') {
       this.logger.debug('Consumer paused');
       this.consumer.consume(1, this.consumeCallback);

--- a/packages/steveo/src/consumers/kafka.ts
+++ b/packages/steveo/src/consumers/kafka.ts
@@ -11,6 +11,7 @@ import { getDuration } from '../lib/context';
 import { IRunner, Logger, KafkaConfiguration } from '../common';
 import { Steveo } from '..';
 import { Resource } from '../lib/pool';
+import { sleep } from '../lib/utils';
 
 class JsonParsingError extends Error {}
 
@@ -188,6 +189,7 @@ class KafkaRunner
 
     if (this.state === 'paused') {
       this.logger.debug('Consumer paused');
+      await sleep(1000);
       this.consumer.consume(1, this.consumeCallback);
       return;
     }

--- a/packages/steveo/src/consumers/kafka.ts
+++ b/packages/steveo/src/consumers/kafka.ts
@@ -185,6 +185,12 @@ class KafkaRunner
       this.disconnect();
       return;
     }
+    
+    if (this.state === 'paused') {
+      this.logger.debug('Consumer paused');
+      this.consumer.consume(1, this.consumeCallback);
+      return;
+    }
 
     if (err) {
       const message = 'Error while consumption';
@@ -198,11 +204,7 @@ class KafkaRunner
         await this.receive(messages[0]);
       }
     } finally {
-      if (this.state === 'paused') {
-        this.logger.debug('Consumer paused');
-      } else {
-        this.consumer.consume(1, this.consumeCallback);
-      }
+      this.consumer.consume(1, this.consumeCallback);
     }
   };
 
@@ -296,19 +298,6 @@ class KafkaRunner
     this.logger.debug(`stopping consumer ${this.name}`);
     this.consumer.disconnect();
     this.adminClient.disconnect();
-  }
-
-  async resume() {
-    if (!this.consumerReady) return;
-    if (!this.consumer.isConnected()) {
-      throw new Error('Lost connection to kafka');
-    }
-    if (this.state === 'terminating') return;
-    if (this.state === 'paused') {
-      this.logger.debug('Resuming consumer');
-      this.state = 'running';
-      this.consumer.consume(1, this.consumeCallback);
-    }
   }
 }
 


### PR DESCRIPTION
Kafka consumers in steveo use a non-flowing mode which means we explicitly tell the consumer to consumer a new message (and we manually commit the message offset).

With the new manager state logic, consumers now look at statuses in their polling/streaming callback. When a kafka consumer is `paused` we break the callback loop by returning and not telling it to consume, so the consumer never restarts, even though the steveo instance's state changes to `running`.

This PR adds a logic to ignore messages if the consumer is supposed to be paused and does not commit. It'll re-read the same message till the steveo instance goes to either `terminating` or `running`