### PR TITLE
Kafka - Change metadata parameters when checking consumer health

### DIFF
--- a/.changeset/thick-icons-compare.md
+++ b/.changeset/thick-icons-compare.md
@@ -1,0 +1,5 @@
+---
+"steveo": minor
+---
+
+Change health check parameters - Kafka consumers

--- a/packages/steveo/package.json
+++ b/packages/steveo/package.json
@@ -47,7 +47,7 @@
     "lodash.merge": "4.6.2",
     "lodash.shuffle": "^4.2.0",
     "moment": "2.29.4",
-    "node-rdkafka": "2.16.1",
+    "node-rdkafka": "2.17.0",
     "null-logger": "^2.0.0",
     "rsmq": "^0.12.4",
     "uuid": "^9.0.0"
@@ -81,7 +81,6 @@
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-unicorn": "45.0.2",
     "mocha": "10.2.0",
-    "node-rdkafka": "2.16.1",
     "nyc": "15.1.0",
     "pino": "^8.14.1",
     "prettier": "2.8.8",

--- a/packages/steveo/src/consumers/kafka.ts
+++ b/packages/steveo/src/consumers/kafka.ts
@@ -165,15 +165,22 @@ class KafkaRunner
       /**
        * if you are concerned about potential performance issues,
        * don't be, it returns early if it has a local connection status
-       * only fallsback to the kafka client if the local connection status is missing
+       * only falls back to the kafka client if the local connection status is missing
        */
-      this.consumer.getMetadata({}, (err, meta) => {
-        this.logger.debug(`metadata response meta=${meta} err=${err}`);
-        if (err) {
-          return reject(err);
+      this.consumer.getMetadata(
+        {
+          allTopics: false,
+          topic: '',
+          timeout: 1000,
+        },
+        (err, meta) => {
+          this.logger.debug(`metadata response meta=${meta} err=${err}`);
+          if (err) {
+            return reject(err);
+          }
+          return resolve(meta);
         }
-        return resolve(meta);
-      });
+      );
     });
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4562,10 +4562,10 @@ node-preload@^0.2.1:
   dependencies:
     process-on-spawn "^1.0.0"
 
-node-rdkafka@2.16.1:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-2.16.1.tgz#45efcf4bbf386240a88d51a6c9a1196ae044f78d"
-  integrity sha512-fiZJGl/w9QnACLhfVTYuS4V4WxSmVSbxhXyxL+B0SgRWEa8kA1NpdiB+gHPG71C3CqjbvYEfTJWhjd/1y0OeSA==
+node-rdkafka@2.17.0:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-2.17.0.tgz#d0fe79165098d6fcacdfb0570abe2adf861a515b"
+  integrity sha512-vFABzRcE5FaH0WqfqJRxDoqeG6P8UEB3M4qFQ7SkwMgQueMMO78+fm8MYfl5hLW3bBYfBekK2BXIIr0lDQtSEQ==
   dependencies:
     bindings "^1.3.1"
     nan "^2.17.0"


### PR DESCRIPTION
We are using `getMetadata` api to get us information of the broker we are connected to. By default it fetches the whole object with all topics. 

This PR changes it to fetch minimal info so we check connection. Health check wouldn't care about all topics.

This will fix the broker unknown topic error we are seeing with consumers (verified on my local, to be tested on our pods).