### PR TITLE
Cloudwatch metrics emitter - Set AWS region

### DIFF
--- a/.changeset/flat-cherries-exercise.md
+++ b/.changeset/flat-cherries-exercise.md
@@ -1,0 +1,5 @@
+---
+"@steveojs/cloudwatch": patch
+---
+
+Set aws region

--- a/packages/cloudwatch/src/index.ts
+++ b/packages/cloudwatch/src/index.ts
@@ -19,7 +19,8 @@ type Job = PrismaJob | JobInstance;
 type JobAttributes = SequelizeJob | PrismaJob;
 
 const client = new CloudWatchClient({
-  region: process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || 'us-east-1'
+  region:
+    process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || 'us-east-1',
 });
 const Namespace = 'Steveo-DB-Jobs';
 

--- a/packages/cloudwatch/src/index.ts
+++ b/packages/cloudwatch/src/index.ts
@@ -18,7 +18,9 @@ import {
 type Job = PrismaJob | JobInstance;
 type JobAttributes = SequelizeJob | PrismaJob;
 
-const client = new CloudWatchClient();
+const client = new CloudWatchClient({
+  region: process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || 'us-east-1'
+});
 const Namespace = 'Steveo-DB-Jobs';
 
 export const schedulerMetrics = (


### PR DESCRIPTION
The cloudwatch client isn't able to pick up the region through environment vars. This PR explicitly sets it.