### PR TITLE
[C1-971] Replace lunartick with rust rrule

### DIFF
--- a/.changeset/lemon-beds-occur.md
+++ b/.changeset/lemon-beds-occur.md
@@ -1,0 +1,6 @@
+---
+"@steveojs/scheduler-sequelize": major
+"@steveojs/scheduler-prisma": major
+---
+
+Use rrule-rust instead of lunartick for rrule strings

--- a/packages/scheduler-prisma/package.json
+++ b/packages/scheduler-prisma/package.json
@@ -37,11 +37,11 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@ordermentum/lunartick": "^0.0.19",
     "@prisma/client": "5.7.1",
     "bunyan": "^1.8.15",
     "cron-parser": "^3.5.0",
     "moment-timezone": "^0.5.33",
+    "rrule-rust": "^1.2.0",
     "typed-emitter": "^1.3.1",
     "uuid": "^8.3.2"
   },

--- a/packages/scheduler-prisma/src/definitions/lunartick.d.ts
+++ b/packages/scheduler-prisma/src/definitions/lunartick.d.ts
@@ -1,1 +1,0 @@
-declare module '@ordermentum/lunartick';

--- a/packages/scheduler-prisma/src/helpers.ts
+++ b/packages/scheduler-prisma/src/helpers.ts
@@ -1,5 +1,5 @@
 import moment from 'moment-timezone';
-import Rule from '@ordermentum/lunartick';
+import { RRuleSet } from 'rrule-rust';
 import TypedEventEmitter from 'typed-emitter';
 import { Job, PrismaClient } from '@prisma/client';
 import {
@@ -19,27 +19,20 @@ export const isHealthy = (heartbeat: number, timeout: number) =>
 export const computeNextRunAt = (
   interval: string,
   timezone = 'UTC'
-): moment.Moment => {
+): string => {
   if (!interval) {
     throw new Error('Invalid interval argument supplied to computeNextRunAt');
   }
 
-  const rule = Rule.parse(interval);
-
-  if (!rule.tzId) {
-    rule.tzId = timezone;
-  }
-
-  if (!rule.byMinute) {
-    rule.byMinute = [0];
-  }
-
-  if (!rule.bySecond) {
-    rule.bySecond = [0];
-  }
-
-  const rrule = new Rule(rule);
-  return rrule.getNext(new Date()).date;
+  const rule = interval
+    .split(';')
+    .filter(b => !b.includes('TZID'))
+    .join(';');
+  const timeISO8601 = moment().tz(timezone).format('YYYYMMDDTHHmmss');
+  const rrule = RRuleSet.parse(
+    `DTSTART;TZID=${timezone}:${timeISO8601}\nRRULE:${rule}\nEXDATE;TZID=${timezone}:${timeISO8601}`
+  );
+  return new Date(rrule.all(1)[0]).toISOString();
 };
 
 /**
@@ -65,14 +58,14 @@ export const resetJob = async (
   events: TypedEventEmitter<Events>
 ) => {
   const nextRunAt = computeNextRunAt(job.repeatInterval, job.timezone);
-  events.emit('reset', job, nextRunAt.toISOString());
+  events.emit('reset', job, nextRunAt);
   return client.job.update({
     // @ts-expect-error namespace is an optional feature
     where: job.namespace
       ? // @ts-expect-error
         { id_namespace: { id: job.id, namespace: job.namespace } }
       : { id: job.id },
-    data: { queued: false, nextRunAt: nextRunAt.toISOString(), failures: 0 },
+    data: { queued: false, nextRunAt, failures: 0 },
   });
 };
 
@@ -196,10 +189,7 @@ const updateFinishTask = async (
         : { id },
     });
   }
-  const nextRunAt = computeNextRunAt(
-    job.repeatInterval,
-    job.timezone
-  ).toISOString();
+  const nextRunAt = computeNextRunAt(job.repeatInterval, job.timezone);
   await client.job.update({
     where: namespace
       ? // @ts-expect-error namespace is an optional feature

--- a/packages/scheduler-prisma/src/helpers.ts
+++ b/packages/scheduler-prisma/src/helpers.ts
@@ -12,6 +12,8 @@ import {
 } from './index';
 import { Properties } from './types';
 
+const SIX_MONTHS_IN_MS = 15778476000;
+
 export const isHealthy = (heartbeat: number, timeout: number) =>
   new Date().getTime() - timeout < heartbeat;
 
@@ -24,15 +26,30 @@ export const computeNextRunAt = (
     throw new Error('Invalid interval argument supplied to computeNextRunAt');
   }
 
-  const rule = interval
-    .split(';')
-    .filter(b => !b.includes('TZID'))
-    .join(';');
-  const timeISO8601 = moment().tz(timezone).format('YYYYMMDDTHHmmss');
-  const rrule = RRuleSet.parse(
-    `DTSTART;TZID=${timezone}:${timeISO8601}\nRRULE:${rule}\nEXDATE;TZID=${timezone}:${timeISO8601}`
-  );
-  return new Date(rrule.all(1)[0]).toISOString();
+  const isValidRule = interval.includes('DTSTART');
+
+  if (!isValidRule) {
+    const rule = interval
+      .split(';')
+      .filter(b => !b.includes('TZID'))
+      .join(';');
+
+    const timeISO8601 = moment().tz(timezone).format('YYYYMMDDTHHmmss');
+    const rrule = RRuleSet.parse(
+      `DTSTART;TZID=${timezone}:${timeISO8601}\nRRULE:${rule}\nEXDATE;TZID=${timezone}:${timeISO8601}`
+    );
+    return new Date(rrule.all(1)[0]).toISOString();
+  }
+
+  const rrule = RRuleSet.parse(interval);
+
+  return new Date(
+    rrule.between(
+      new Date().getTime(),
+      new Date().getTime() + SIX_MONTHS_IN_MS,
+      true
+    )[0]
+  ).toISOString();
 };
 
 /**

--- a/packages/scheduler-prisma/src/index.ts
+++ b/packages/scheduler-prisma/src/index.ts
@@ -139,7 +139,7 @@ export interface JobSchedulerInterface {
    * Timestamp helper will perform the following:
    * 1. Adds an accepted at timestamp (as the current timestamp) on the job to signal the job was accepted at this time
    * 2. Runs the callback (whatever the task is)
-   * 3. When the callback runs successfully without any issues, it calculates the next run at for the job using its lunartick (https://www.npmjs.com/package/lunartick) rule and adds the following to the job
+   * 3. When the callback runs successfully without any issues, it calculates the next run at for the job using its ical rrule and adds the following to the job
    * - queued: false //signalling the job is now over and ready to be picked up at the next run time
    * - nextRunAt: timestamp //time to pick up the job
    * - lastFinishedAt: timestamp //when did the job finish

--- a/packages/scheduler-prisma/test/helpers_test.ts
+++ b/packages/scheduler-prisma/test/helpers_test.ts
@@ -6,11 +6,15 @@ import { computeNextRunAt, isHealthy } from '../src/helpers';
 describe('helpers', () => {
   let sandbox: SinonSandbox;
   let clock: SinonFakeTimers;
+  let systemTZ = process.env.TZ;
+
   beforeEach(() => {
+    process.env.TZ = 'Australia/Sydney';
     sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {
+    process.env.TZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
     if(clock) clock.restore();
     sandbox.restore();
   });

--- a/packages/scheduler-prisma/test/helpers_test.ts
+++ b/packages/scheduler-prisma/test/helpers_test.ts
@@ -1,21 +1,46 @@
-import moment from 'moment-timezone';
+import moment, { Moment } from 'moment-timezone';
 import { expect } from 'chai';
-import { computeNextRunAt } from '../src/helpers';
+import sinon, { SinonSandbox } from 'sinon';
+import { computeNextRunAt, isHealthy } from '../src/helpers';
 
 describe('helpers', () => {
+  let sandbox: SinonSandbox;
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
   describe('compute next run at', () => {
     it('Calculates the next date correctly', () => {
       const every3Hours = 'FREQ=HOURLY;INTERVAL=4;BYMINUTE=0';
-      const nextDate = computeNextRunAt(every3Hours);
+      const nextDate = moment(computeNextRunAt(every3Hours));
       expect(nextDate.diff(moment().tz('utc').minute(0), 'hours')).to.equal(3);
     });
 
-    it('Adds defaults if byhour is passed', () => {
-      const atFour = 'FREQ=DAILY;BYHOUR=4';
-      const nextDate = computeNextRunAt(atFour);
-      expect(nextDate.hours()).to.equal(4);
-      expect(nextDate.minutes()).to.equal(0);
-      expect(nextDate.seconds()).to.equal(0);
+    // List of recurrence rules to test
+    // comparator that returns boolean
+    ([
+      ['FREQ=HOURLY;INTERVAL=1', 'UTC', (m: Moment) => moment().tz('utc').diff(m, 'minutes') === -59],
+      ['FREQ=WEEKLY;INTERVAL=1;BYDAY=MO;BYHOUR=16;BYMINUTE=40', 'Australia/Sydney', (m: Moment) => m.day() === 1 && m.hour() === 16 && m.minute() === 40 && ['+1100', '+1000'].some(x => x === m.format('ZZ'))],
+      ['FREQ=WEEKLY;INTERVAL=1;BYDAY=WE;BYHOUR=17;BYMINUTE=40;BYSECOND=0', 'Australia/Sydney', (m: Moment) => m.day() === 3 && m.hour() === 17 && m.minute() === 40 && m.second() === 0  && ['+1100', '+1000'].some(x => x === m.format('ZZ'))],
+      ['FREQ=WEEKLY;BYDAY=TU;INTERVAL=2', 'Australia/Sydney', (m: Moment) => m.day() === 2 && m.diff(moment().tz('Australia/Sydney'), 'week') >= 1 ],
+    ] as [string, string, (m: Moment) => boolean][]).forEach( ([rule, timezone, comparator]) => {
+      it(`Calculates the next date for rule ${rule} correctly`, () => {
+        expect(comparator(moment(computeNextRunAt(rule, timezone)))).to.be.true;
+      });
+    });
+  });
+
+  describe('healthy', () => {
+    it('succeeds', () => {
+      expect(isHealthy(new Date().getTime(), 50000)).to.be.true;
+    });
+    it('fails', () => {
+      expect(isHealthy(moment().subtract(5, 'hours').unix(), 60 * 1000 * 5)).to
+        .be.false;
     });
   });
 });

--- a/packages/scheduler-prisma/test/helpers_test.ts
+++ b/packages/scheduler-prisma/test/helpers_test.ts
@@ -1,15 +1,17 @@
 import moment, { Moment } from 'moment-timezone';
 import { expect } from 'chai';
-import sinon, { SinonSandbox } from 'sinon';
+import sinon, { SinonSandbox, SinonFakeTimers } from 'sinon';
 import { computeNextRunAt, isHealthy } from '../src/helpers';
 
 describe('helpers', () => {
   let sandbox: SinonSandbox;
+  let clock: SinonFakeTimers;
   beforeEach(() => {
     sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {
+    if(clock) clock.restore();
     sandbox.restore();
   });
 
@@ -26,11 +28,55 @@ describe('helpers', () => {
       ['FREQ=HOURLY;INTERVAL=1', 'UTC', (m: Moment) => moment().tz('utc').diff(m, 'minutes') === -59],
       ['FREQ=WEEKLY;INTERVAL=1;BYDAY=MO;BYHOUR=16;BYMINUTE=40', 'Australia/Sydney', (m: Moment) => m.day() === 1 && m.hour() === 16 && m.minute() === 40 && ['+1100', '+1000'].some(x => x === m.format('ZZ'))],
       ['FREQ=WEEKLY;INTERVAL=1;BYDAY=WE;BYHOUR=17;BYMINUTE=40;BYSECOND=0', 'Australia/Sydney', (m: Moment) => m.day() === 3 && m.hour() === 17 && m.minute() === 40 && m.second() === 0  && ['+1100', '+1000'].some(x => x === m.format('ZZ'))],
-      ['FREQ=WEEKLY;BYDAY=TU;INTERVAL=2', 'Australia/Sydney', (m: Moment) => m.day() === 2 && m.diff(moment().tz('Australia/Sydney'), 'week') >= 1 ],
     ] as [string, string, (m: Moment) => boolean][]).forEach( ([rule, timezone, comparator]) => {
       it(`Calculates the next date for rule ${rule} correctly`, () => {
         expect(comparator(moment(computeNextRunAt(rule, timezone)))).to.be.true;
       });
+    });
+
+    it('Can handle fortnightly rrule with a set day', () => {
+      // set the current date to a thursday
+      // At AEDT this will be 2024-01-25T03:00:00+11:00
+      clock = sinon.useFakeTimers(new Date('2024-01-24T16:00:00Z').getTime());
+      const rule = 'FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
+      const nextDate = moment(computeNextRunAt(rule, 'Australia/Sydney'));
+      expect([nextDate.date(), nextDate.month(), nextDate.year()]).to.eqls([7, 1, 2024]); 
+    });
+
+    it('Can handle DST switchover with a rrule', () => {
+      // set the current date to 6th April 2024
+      // At AEDT this will be 2024-04-06T03:00:00+11:00
+      clock = sinon.useFakeTimers(new Date('2024-04-05T16:00:00Z').getTime());
+      const rule = 'FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
+      const nextDate = computeNextRunAt(rule, 'Australia/Sydney');
+      expect(nextDate).to.eqls('2024-04-17T02:00:00.000Z');
+      const parsed = moment(nextDate);
+      expect([parsed.date(), parsed.month(), parsed.year(), parsed.hours(), parsed.minutes(), parsed.format('ZZ')]).to.eqls([17, 3, 2024, 12, 0, '+1000']);
+    });
+
+    it('Can handle fortnightly rrule with a dtstart', () => {
+      const rule = 'DTSTART;TZID=Australia/Sydney:20230126T030000\nRRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
+      // set the current date to a thursday
+      // At AEDT this will be 2024-01-25T03:00:00+11:00
+      clock = sinon.useFakeTimers(new Date('2023-01-25T16:00:00Z').getTime());
+      let nextDate = moment(computeNextRunAt(rule, 'Australia/Sydney'));
+      expect([nextDate.date(), nextDate.month(), nextDate.year()]).to.eqls([8, 1, 2023]); 
+      clock.restore();
+      // After 16/02/2023, starting from 26/01/2023, the next run should be 22/02/2023
+      clock = sinon.useFakeTimers(new Date('2023-02-16T16:00:00Z').getTime());
+      nextDate = moment(computeNextRunAt(rule, 'Australia/Sydney'));
+      expect([nextDate.date(), nextDate.month(), nextDate.year()]).to.eqls([22, 1, 2023]); 
+    });
+
+    it('Can handle DST switchover with a rrule with DTSTART', () => {
+      // set the current date to 6th April 2024
+      // At AEDT this will be 2024-04-06T03:00:00+11:00
+      clock = sinon.useFakeTimers(new Date('2024-04-05T16:00:00Z').getTime());
+      const rule = 'DTSTART;TZID=Australia/Sydney:20240406T030000\nRRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
+      const nextDate = computeNextRunAt(rule, 'Australia/Sydney');
+      expect(nextDate).to.eqls('2024-04-17T02:00:00.000Z');
+      const parsed = moment(nextDate);
+      expect([parsed.date(), parsed.month(), parsed.year(), parsed.hours(), parsed.minutes(), parsed.format('ZZ')]).to.eqls([17, 3, 2024, 12, 0, '+1000']);
     });
   });
 

--- a/packages/scheduler-prisma/tsconfig.json
+++ b/packages/scheduler-prisma/tsconfig.json
@@ -27,9 +27,6 @@
     "exclude": [
       "lib",
       "node_modules"
-    ],
-    "files": [
-      "src/definitions/lunartick.d.ts"
     ]
   }
   

--- a/packages/scheduler-sequelize/package.json
+++ b/packages/scheduler-sequelize/package.json
@@ -36,11 +36,11 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@ordermentum/lunartick": "^0.0.19",
     "bunyan": "^1.8.15",
     "cron-parser": "^3.5.0",
     "moment-timezone": "^0.5.33",
     "pg": "^8.6.0",
+    "rrule-rust": "^1.2.0",
     "sequelize": "^6.6.2",
     "typed-emitter": "^1.3.1",
     "uuid": "^8.3.2"

--- a/packages/scheduler-sequelize/src/maintenance.ts
+++ b/packages/scheduler-sequelize/src/maintenance.ts
@@ -20,7 +20,7 @@ export const resetJob = async (
     return;
   }
   const nextRunAt = computeNextRunAt(job.repeatInterval, job.timezone);
-  events.emit('reset', job.get(), nextRunAt.toISOString());
+  events.emit('reset', job.get(), nextRunAt);
   await job.update({
     queued: false,
     nextRunAt,

--- a/packages/scheduler-sequelize/test/helpers_test.ts
+++ b/packages/scheduler-sequelize/test/helpers_test.ts
@@ -1,15 +1,17 @@
 import moment, { Moment } from 'moment-timezone';
 import { expect } from 'chai';
-import sinon, { SinonSandbox } from 'sinon';
+import sinon, { SinonSandbox, SinonFakeTimers } from 'sinon';
 import { computeNextRunAt, isHealthy } from '../src/helpers';
 
 describe('helpers', () => {
   let sandbox: SinonSandbox;
+  let clock: SinonFakeTimers;
   beforeEach(() => {
     sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {
+    if(clock) clock.restore();
     sandbox.restore();
   });
 
@@ -26,11 +28,55 @@ describe('helpers', () => {
       ['FREQ=HOURLY;INTERVAL=1', 'UTC', (m: Moment) => moment().tz('utc').diff(m, 'minutes') === -59],
       ['FREQ=WEEKLY;INTERVAL=1;BYDAY=MO;BYHOUR=16;BYMINUTE=40', 'Australia/Sydney', (m: Moment) => m.day() === 1 && m.hour() === 16 && m.minute() === 40 && ['+1100', '+1000'].some(x => x === m.format('ZZ'))],
       ['FREQ=WEEKLY;INTERVAL=1;BYDAY=WE;BYHOUR=17;BYMINUTE=40;BYSECOND=0', 'Australia/Sydney', (m: Moment) => m.day() === 3 && m.hour() === 17 && m.minute() === 40 && m.second() === 0  && ['+1100', '+1000'].some(x => x === m.format('ZZ'))],
-      ['FREQ=WEEKLY;BYDAY=TU;INTERVAL=2', 'Australia/Sydney', (m: Moment) => m.day() === 2 && m.diff(moment().tz('Australia/Sydney'), 'week') >= 1 ],
     ] as [string, string, (m: Moment) => boolean][]).forEach( ([rule, timezone, comparator]) => {
       it(`Calculates the next date for rule ${rule} correctly`, () => {
         expect(comparator(moment(computeNextRunAt(rule, timezone)))).to.be.true;
       });
+    });
+
+    it('Can handle fortnightly rrule with a set day', () => {
+      // set the current date to a thursday
+      // At AEDT this will be 2024-01-25T03:00:00+11:00
+      clock = sinon.useFakeTimers(new Date('2024-01-24T16:00:00Z').getTime());
+      const rule = 'FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
+      const nextDate = moment(computeNextRunAt(rule, 'Australia/Sydney'));
+      expect([nextDate.date(), nextDate.month(), nextDate.year()]).to.eqls([7, 1, 2024]); 
+    });
+
+    it('Can handle DST switchover with a rrule', () => {
+      // set the current date to 6th April 2024
+      // At AEDT this will be 2024-04-06T03:00:00+11:00
+      clock = sinon.useFakeTimers(new Date('2024-04-05T16:00:00Z').getTime());
+      const rule = 'FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
+      const nextDate = computeNextRunAt(rule, 'Australia/Sydney');
+      expect(nextDate).to.eqls('2024-04-17T02:00:00.000Z');
+      const parsed = moment(nextDate);
+      expect([parsed.date(), parsed.month(), parsed.year(), parsed.hours(), parsed.minutes(), parsed.format('ZZ')]).to.eqls([17, 3, 2024, 12, 0, '+1000']);
+    });
+
+    it('Can handle fortnightly rrule with a dtstart', () => {
+      const rule = 'DTSTART;TZID=Australia/Sydney:20230126T030000\nRRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
+      // set the current date to a thursday
+      // At AEDT this will be 2024-01-25T03:00:00+11:00
+      clock = sinon.useFakeTimers(new Date('2023-01-25T16:00:00Z').getTime());
+      let nextDate = moment(computeNextRunAt(rule, 'Australia/Sydney'));
+      expect([nextDate.date(), nextDate.month(), nextDate.year()]).to.eqls([8, 1, 2023]); 
+      clock.restore();
+      // After 16/02/2023, starting from 26/01/2023, the next run should be 22/02/2023
+      clock = sinon.useFakeTimers(new Date('2023-02-16T16:00:00Z').getTime());
+      nextDate = moment(computeNextRunAt(rule, 'Australia/Sydney'));
+      expect([nextDate.date(), nextDate.month(), nextDate.year()]).to.eqls([22, 1, 2023]); 
+    });
+
+    it('Can handle DST switchover with a rrule with DTSTART', () => {
+      // set the current date to 6th April 2024
+      // At AEDT this will be 2024-04-06T03:00:00+11:00
+      clock = sinon.useFakeTimers(new Date('2024-04-05T16:00:00Z').getTime());
+      const rule = 'DTSTART;TZID=Australia/Sydney:20240406T030000\nRRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
+      const nextDate = computeNextRunAt(rule, 'Australia/Sydney');
+      expect(nextDate).to.eqls('2024-04-17T02:00:00.000Z');
+      const parsed = moment(nextDate);
+      expect([parsed.date(), parsed.month(), parsed.year(), parsed.hours(), parsed.minutes(), parsed.format('ZZ')]).to.eqls([17, 3, 2024, 12, 0, '+1000']);
     });
   });
 

--- a/packages/scheduler-sequelize/test/helpers_test.ts
+++ b/packages/scheduler-sequelize/test/helpers_test.ts
@@ -6,11 +6,14 @@ import { computeNextRunAt, isHealthy } from '../src/helpers';
 describe('helpers', () => {
   let sandbox: SinonSandbox;
   let clock: SinonFakeTimers;
+
   beforeEach(() => {
+    process.env.TZ = 'Australia/Sydney';
     sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {
+    process.env.TZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
     if(clock) clock.restore();
     sandbox.restore();
   });

--- a/packages/scheduler-sequelize/test/helpers_test.ts
+++ b/packages/scheduler-sequelize/test/helpers_test.ts
@@ -1,4 +1,4 @@
-import moment from 'moment-timezone';
+import moment, { Moment } from 'moment-timezone';
 import { expect } from 'chai';
 import sinon, { SinonSandbox } from 'sinon';
 import { computeNextRunAt, isHealthy } from '../src/helpers';
@@ -16,16 +16,21 @@ describe('helpers', () => {
   describe('compute next run at', () => {
     it('Calculates the next date correctly', () => {
       const every3Hours = 'FREQ=HOURLY;INTERVAL=4;BYMINUTE=0';
-      const nextDate = computeNextRunAt(every3Hours);
+      const nextDate = moment(computeNextRunAt(every3Hours));
       expect(nextDate.diff(moment().tz('utc').minute(0), 'hours')).to.equal(3);
     });
 
-    it('Adds defaults if byhour is passed', () => {
-      const atFour = 'FREQ=DAILY;BYHOUR=4';
-      const nextDate = computeNextRunAt(atFour);
-      expect(nextDate.hours()).to.equal(4);
-      expect(nextDate.minutes()).to.equal(0);
-      expect(nextDate.seconds()).to.equal(0);
+    // List of recurrence rules to test
+    // comparator that returns boolean
+    ([
+      ['FREQ=HOURLY;INTERVAL=1', 'UTC', (m: Moment) => moment().tz('utc').diff(m, 'minutes') === -59],
+      ['FREQ=WEEKLY;INTERVAL=1;BYDAY=MO;BYHOUR=16;BYMINUTE=40', 'Australia/Sydney', (m: Moment) => m.day() === 1 && m.hour() === 16 && m.minute() === 40 && ['+1100', '+1000'].some(x => x === m.format('ZZ'))],
+      ['FREQ=WEEKLY;INTERVAL=1;BYDAY=WE;BYHOUR=17;BYMINUTE=40;BYSECOND=0', 'Australia/Sydney', (m: Moment) => m.day() === 3 && m.hour() === 17 && m.minute() === 40 && m.second() === 0  && ['+1100', '+1000'].some(x => x === m.format('ZZ'))],
+      ['FREQ=WEEKLY;BYDAY=TU;INTERVAL=2', 'Australia/Sydney', (m: Moment) => m.day() === 2 && m.diff(moment().tz('Australia/Sydney'), 'week') >= 1 ],
+    ] as [string, string, (m: Moment) => boolean][]).forEach( ([rule, timezone, comparator]) => {
+      it(`Calculates the next date for rule ${rule} correctly`, () => {
+        expect(comparator(moment(computeNextRunAt(rule, timezone)))).to.be.true;
+      });
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1361,29 +1361,10 @@
   resolved "https://registry.yarnpkg.com/@ordermentum/eslint-config-ordermentum/-/eslint-config-ordermentum-2.1.0.tgz#f13720306aac8f26cf139bd83032d70690e95a63"
   integrity sha512-FXPumiQoKGzRVBRYLXgaeJ1NhIVPl2yZ4K4BGzYHspLhe7DsQc05gQzIUzMj+mOLjx0SPkwafJx2oCQWdwzOig==
 
-"@ordermentum/lunartick@^0.0.19":
-  version "0.0.19"
-  resolved "https://registry.yarnpkg.com/@ordermentum/lunartick/-/lunartick-0.0.19.tgz#4cc0b0bc56a9377f44e6dfad4238acc020160b92"
-  integrity sha512-gL03DvxsIvhiG90AMDLo+R0RKWFl4JdGf56c8jaWtxqNpq6fASAcpzwnPjYbZdG284keQ67AJ04IO5gQljrBEQ==
-  dependencies:
-    moment-timezone "^0.5.11"
-
 "@prisma/client@5.7.1":
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/@prisma/client/-/client-5.7.1.tgz#a124afd05663267f7255a639a81d28303684a063"
   integrity sha512-TUSa4nUcC4nf/e7X3jyO1pEd6XcI/TLRCA0KjkA46RDIpxUaRsBYEOqITwXRW2c0bMFyKcCRXrH4f7h4q9oOlg==
-
-"@prisma/client@^4.3.1":
-  version "4.16.2"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-4.16.2.tgz#3bb9ebd49b35c8236b3d468d0215192267016e2b"
-  integrity sha512-qCoEyxv1ZrQ4bKy39GnylE8Zq31IRmm8bNhNbZx7bF2cU5aiCCnSa93J2imF88MBjn7J9eUQneNxUQVJdl/rPQ==
-  dependencies:
-    "@prisma/engines-version" "4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81"
-
-"@prisma/engines-version@4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81":
-  version "4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81.tgz#d3b5dcf95b6d220e258cbf6ae19b06d30a7e9f14"
-  integrity sha512-q617EUWfRIDTriWADZ4YiWRZXCa/WuhNgLTVd+HqWLffjMSPzyM5uOWoauX91wvQClSKZU4pzI4JJLQ9Kl62Qg==
 
 "@prisma/engines@4.16.2":
   version "4.16.2"
@@ -1442,6 +1423,76 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
+
+"@rrule-rust/lib-android-arm-eabi@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@rrule-rust/lib-android-arm-eabi/-/lib-android-arm-eabi-1.2.0.tgz#867e4449b49d0ca4e79e303efd25e4279466ea94"
+  integrity sha512-H5mojmF+vy7T11SQmQTtxHuiUf3yV48A/aj2DlgQXWXdTEACaYKef8/3luD16kbRb0/jKt86DNe0CURCnLIMIw==
+
+"@rrule-rust/lib-android-arm64@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@rrule-rust/lib-android-arm64/-/lib-android-arm64-1.2.0.tgz#5dc5a3901d46893e1f024dbb2dd4de3ba4d43044"
+  integrity sha512-A3QEdxpSEQ0gUlrhtqrg9S/vcKL6G1PD/ZOH3Lmn/W5WQvqXun5KsJSuUBUPLmJUL9yIsVchZ3miTb8yp/9xAA==
+
+"@rrule-rust/lib-darwin-arm64@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@rrule-rust/lib-darwin-arm64/-/lib-darwin-arm64-1.2.0.tgz#6c8b7bba0744805e3fe0b332031d00fc106823b8"
+  integrity sha512-nUYlLJlxGcrBo0Snl7FirmqTNUDPWx8DNA7dxQT4zNc0RNhwCvI8zR4v968yMg+vgyjYlp12J31jN5rWw5c3EA==
+
+"@rrule-rust/lib-darwin-universal@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@rrule-rust/lib-darwin-universal/-/lib-darwin-universal-1.2.0.tgz#41ea295d295276bfc9e1c0d82e8be076ba5b46b9"
+  integrity sha512-tz1NB8xz1iIq5oTrVKja8dIsO5okiaV28X7izh8nYWb9clN4C67m/lKdxxh27KYKVKZHMoG23ZidiLx+9XhuNA==
+
+"@rrule-rust/lib-darwin-x64@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@rrule-rust/lib-darwin-x64/-/lib-darwin-x64-1.2.0.tgz#4a3ad984ccec6bddc9f57dc1e76a0283cd44d997"
+  integrity sha512-zMZgd96Y1PtsvsLrHo+Ay7TlkZxOC3dQZJCNIpSDtxnK6tG9L3EKEfgiEaIzhPMG8cC7n830Wdko7pegvHbW8w==
+
+"@rrule-rust/lib-freebsd-x64@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@rrule-rust/lib-freebsd-x64/-/lib-freebsd-x64-1.2.0.tgz#d789aea3f3114f0907dad785e4de6941de8dafde"
+  integrity sha512-AbrB51vFT9n/kLQ3ysV0VasRUc7wtZL3zsd1/v8hIStHdajDJQ6Tev+KBFT5cAF5tt4Xt4C9OkM4Y3yU4pHwlw==
+
+"@rrule-rust/lib-linux-arm-gnueabihf@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@rrule-rust/lib-linux-arm-gnueabihf/-/lib-linux-arm-gnueabihf-1.2.0.tgz#7def3363d3a65cab40d128e2f47f57ef0148fe3d"
+  integrity sha512-2dXPu9j5T1dBdqGBkhBpssx4dIpQHlvYFWxxBaRvsF5UQhvcYms1K52i6c+FagvQPmshztNl6kBvu3MNjtrsDg==
+
+"@rrule-rust/lib-linux-arm64-gnu@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@rrule-rust/lib-linux-arm64-gnu/-/lib-linux-arm64-gnu-1.2.0.tgz#b15019002bd3999714bb66992674a950bba60a01"
+  integrity sha512-nI2l0ELiDfm9xHrAd5n/rxP/hgCHNkayroboCDInSWf1iLNNEM+E5Cpse2zjNVLo4HYsVA9EmQFVV/Xu2wnBoQ==
+
+"@rrule-rust/lib-linux-arm64-musl@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@rrule-rust/lib-linux-arm64-musl/-/lib-linux-arm64-musl-1.2.0.tgz#8b5d3b01ca8666aa5e6df300c2901e9b56930d77"
+  integrity sha512-DDUVXV423LDxQ5iCL/vw9cZad8XOagtG209I8eu12QdKeGsLIJbWP8rx5G3nyFA4xA3iKwalU85VG9r+i7+cxA==
+
+"@rrule-rust/lib-linux-x64-gnu@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@rrule-rust/lib-linux-x64-gnu/-/lib-linux-x64-gnu-1.2.0.tgz#12b1e7410148c810ec3e1105cb905e13f6bb61a4"
+  integrity sha512-YVYUNm5hh9ZSF7lR1Yr/CDM4tgFa53AkgMsMOghsWZfJNNuSeLvBiuv1j13/xhkJHaN/uOfYgca5cAuj9uj5Jg==
+
+"@rrule-rust/lib-linux-x64-musl@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@rrule-rust/lib-linux-x64-musl/-/lib-linux-x64-musl-1.2.0.tgz#0e9f56b73fb78945ed72f55733790b91247c4a08"
+  integrity sha512-kXdHL4U5DlysFybCyQjt1jv5tMcJ2iS9ds4DnHjBTFNliv3XGp+LmNIZC8AhslMFlPlbHtczdl8GQm8mXC0QoA==
+
+"@rrule-rust/lib-win32-arm64-msvc@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@rrule-rust/lib-win32-arm64-msvc/-/lib-win32-arm64-msvc-1.2.0.tgz#3e6d709d1cff8dffe8f0b450647ca2ff532ae971"
+  integrity sha512-fwbaYdXYpxwop3VSckncL0wY1lIoDfF152+oEoUDo7kVEhCcLkAKy7Pn9/L/85SNvfT8993H/qDn9LK2PXWWeA==
+
+"@rrule-rust/lib-win32-ia32-msvc@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@rrule-rust/lib-win32-ia32-msvc/-/lib-win32-ia32-msvc-1.2.0.tgz#e61d191a263a9861d3dc42c55752bc006925b076"
+  integrity sha512-SUnZAhKMJuvlVMNXKqot19E8hSKRNSXVGYNNTP53xNdfstnO7BVsIfq997Chy9Zf58sO05YTBlbyd7zB2E1ExA==
+
+"@rrule-rust/lib-win32-x64-msvc@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@rrule-rust/lib-win32-x64-msvc/-/lib-win32-x64-msvc-1.2.0.tgz#f4ab63296f823c3459e2022fc8fafc90552941f7"
+  integrity sha512-7nksl0zEv/XdsvmodErqneeAUXKidqQcbyMc8g3CRwR+lurd+cdHN5lxfAd/EQftcEUg1qucHmHIOckd+w2llg==
 
 "@sentry-internal/tracing@7.91.0":
   version "7.91.0"
@@ -1931,35 +1982,6 @@
     "@smithy/abort-controller" "^2.0.15"
     "@smithy/types" "^2.7.0"
     tslib "^2.5.0"
-
-"@steveojs/scheduler-prisma@*":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@steveojs/scheduler-prisma/-/scheduler-prisma-6.0.1.tgz#5c4235600f7feb72951bdc0877e9de1e924f7577"
-  integrity sha512-QRvJU1Uim2AafGUcAPRRHtlowfpNTfw/FqmTG692TnPfdjw4Q30GVwcWApqo11V0YdM+ohGJPOfXO6SqjO7bjQ==
-  dependencies:
-    "@ordermentum/lunartick" "^0.0.19"
-    "@prisma/client" "^4.3.1"
-    bunyan "^1.8.15"
-    cron-parser "^3.5.0"
-    moment-timezone "^0.5.33"
-    pg "^8.6.0"
-    sequelize "^6.6.2"
-    typed-emitter "^1.3.1"
-    uuid "^8.3.2"
-
-"@steveojs/scheduler-sequelize@*":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@steveojs/scheduler-sequelize/-/scheduler-sequelize-6.0.1.tgz#beecac835a7863e8da67a953490ea931e81d4d6d"
-  integrity sha512-1VCLxm8YFoYTIVsTc6mVL1U5JvynEmY+QG9R+4XGWDsCrVndeDhgouc8OUGBxlCsJHUKjQ9QCPmLVTU4xp8MSw==
-  dependencies:
-    "@ordermentum/lunartick" "^0.0.19"
-    bunyan "^1.8.15"
-    cron-parser "^3.5.0"
-    moment-timezone "^0.5.33"
-    pg "^8.6.0"
-    sequelize "^6.6.2"
-    typed-emitter "^1.3.1"
-    uuid "^8.3.2"
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.8"
@@ -2491,6 +2513,11 @@ array-buffer-byte-length@^1.0.0:
   dependencies:
     call-bind "^1.0.2"
     is-array-buffer "^3.0.1"
+
+array-ify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-ify/-/array-ify-1.0.0.tgz#9e528762b4a9066ad163a6962a364418e9626ece"
+  integrity sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==
 
 array-includes@^3.1.1, array-includes@^3.1.3, array-includes@^3.1.5, array-includes@^3.1.6:
   version "3.1.6"
@@ -3044,6 +3071,14 @@ commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz"
 
+compare-func@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/compare-func/-/compare-func-2.0.0.tgz#fb65e75edbddfd2e568554e8b5b05fff7a51fcb3"
+  integrity sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==
+  dependencies:
+    array-ify "^1.0.0"
+    dot-prop "^5.1.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
@@ -3062,6 +3097,13 @@ confusing-browser-globals@^1.0.10:
   version "1.0.10"
   resolved "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz"
   integrity sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==
+
+conventional-changelog-conventionalcommits@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz#aa5da0f1b2543094889e8cf7616ebe1a8f5c70d5"
+  integrity sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==
+  dependencies:
+    compare-func "^2.0.0"
 
 convert-source-map@^1.7.0:
   version "1.7.0"
@@ -3282,6 +3324,13 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dot-prop@^5.1.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.3.0.tgz#90ccce708cd9cd82cc4dc8c3ddd9abdd55b20e88"
+  integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
+  dependencies:
+    is-obj "^2.0.0"
 
 dottie@^2.0.6:
   version "2.0.6"
@@ -4735,6 +4784,11 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-obj@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
+  integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
+
 is-path-inside@^3.0.3:
   version "3.0.3"
   resolved "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz"
@@ -5451,7 +5505,7 @@ mocha@9.0.0:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
-moment-timezone@*, moment-timezone@^0.5.11, moment-timezone@^0.5.33, moment-timezone@^0.5.43:
+moment-timezone@*, moment-timezone@^0.5.33, moment-timezone@^0.5.43:
   version "0.5.44"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.44.tgz#a64a4e47b68a43deeab5ae4eb4f82da77cdf595f"
   integrity sha512-nv3YpzI/8lkQn0U6RkLd+f0W/zy/JnoR5/EyPz/dNkPTBjA2jNLCVxaiQ8QpeLymhSZvX0wCL5s27NQWdOPwAw==
@@ -6504,6 +6558,28 @@ rimraf@~2.4.0:
   integrity sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==
   dependencies:
     glob "^6.0.1"
+
+rrule-rust@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/rrule-rust/-/rrule-rust-1.2.0.tgz#1406a2bd20f4c1b1f0fc496dcd5eee6e4328cc87"
+  integrity sha512-iyeHC8L5cqzytrQYJL+wF9eW08zgCniETxlzZj9zfIL4ekOT3P33w2Dp/nG6Pqida3oUMsLLLXWUi0I7SHx2Vw==
+  dependencies:
+    conventional-changelog-conventionalcommits "^7.0.2"
+  optionalDependencies:
+    "@rrule-rust/lib-android-arm-eabi" "1.2.0"
+    "@rrule-rust/lib-android-arm64" "1.2.0"
+    "@rrule-rust/lib-darwin-arm64" "1.2.0"
+    "@rrule-rust/lib-darwin-universal" "1.2.0"
+    "@rrule-rust/lib-darwin-x64" "1.2.0"
+    "@rrule-rust/lib-freebsd-x64" "1.2.0"
+    "@rrule-rust/lib-linux-arm-gnueabihf" "1.2.0"
+    "@rrule-rust/lib-linux-arm64-gnu" "1.2.0"
+    "@rrule-rust/lib-linux-arm64-musl" "1.2.0"
+    "@rrule-rust/lib-linux-x64-gnu" "1.2.0"
+    "@rrule-rust/lib-linux-x64-musl" "1.2.0"
+    "@rrule-rust/lib-win32-arm64-msvc" "1.2.0"
+    "@rrule-rust/lib-win32-ia32-msvc" "1.2.0"
+    "@rrule-rust/lib-win32-x64-msvc" "1.2.0"
 
 rsmq@*, rsmq@^0.12.4:
   version "0.12.4"


### PR DESCRIPTION
Integrates https://github.com/lsndr/rrule-rust that wraps the [rrule crate](https://crates.io/crates/rrule) that follows the [iCalendar (RFC-5545) specification](https://icalendar.org/iCalendar-RFC-5545/3-3-10-recurrence-rule.html) more accurately than the outdated homegrown https://github.com/ordermentum/lunartick

This is tested locally with sequelize ORM.

A workaround needed to be added for rules containing the `TZID` attribute which is added separately with date starts as listed in the iCal RFC. The workaround is to remove the attribute and use the job's timezone field.