### PR TITLE
Release datadog middleware

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,15 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
-      - run: yarn
-      - run: yarn build && yarn lint
+
+      - name: Add NPM Token to .npmrc file
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > ~/.npmrc
+
+      - name: Install Dependencies
+        run: yarn
+
+      - name: Build and lint
+        run: yarn build && yarn lint
 
   build:
     runs-on: ubuntu-latest
@@ -52,7 +59,13 @@ jobs:
           localstack start -d
           localstack wait -t 30
           echo "Startup complete"
-      - run: yarn
+
+      - name: Add NPM Token to .npmrc file
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > ~/.npmrc
+
+      - name: Install Dependencies
+        run: yarn
+
       - name: "Run tests"
         run: yarn test
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           node-version: 18.x
 
+      - name: Add NPM Token to .npmrc file
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > ~/.npmrc
+
       - name: Install Dependencies
         run: yarn
 


### PR DESCRIPTION
#### Description

This PR fixes the pipeline issues that are preventing the `yarn install` install command to work due to authentication failure.

The errors are a bit misleading because `yarn` returns a `404` error, even though what's really happening is a `403 Unauthorized` error because the NPM_TOKEN was not being properly set in the `.npmrc` file.

<img width="947" alt="Screenshot 2024-05-02 at 11 00 39" src="https://github.com/ordermentum/steveo/assets/1542502/72f463b5-5188-4c39-98e7-6a3a0e7bc02e">


**PS:** The unit tests are failing, so the pipeline is still failing. However, that will be addressed in a different PR.