### PR TITLE
Allow workflows to be manually triggered

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - develop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
This PR adds the `workflow_dispatch` attribute to `main` and `release` workflows to allow them to be triggered manually.