### PR TITLE
Cleanup-producer-disconnect

### DIFF
--- a/.changeset/afraid-wasps-repair.md
+++ b/.changeset/afraid-wasps-repair.md
@@ -1,0 +1,5 @@
+---
+"steveo": patch
+---
+
+Adds a check to see if the kafka producer is connected before disconnecting. This prevents an error being thrown for an unconnected producer getting a disconnect call.

--- a/packages/datadog/package.json
+++ b/packages/datadog/package.json
@@ -34,6 +34,7 @@
     "nyc": "^15.1.0",
     "prettier": "2.8.8",
     "source-map-support": "0.5.21",
+    "steveo": "^6.1.1",
     "ts-node": "10.9.2",
     "typescript": "^5.3.3"
   },

--- a/packages/steveo/src/producers/kafka.ts
+++ b/packages/steveo/src/producers/kafka.ts
@@ -108,7 +108,13 @@ class KafkaProducer
   }
 
   async stop() {
-    this.producer.disconnect();
+    if (this.producer.isConnected()) {
+      this.producer.disconnect(err => {
+        if (err) {
+          this.logger.error('Error while disconnecting producer', err);
+        }
+      });
+    }
   }
 }
 

--- a/packages/steveo/test/producer/kafka_test.ts
+++ b/packages/steveo/test/producer/kafka_test.ts
@@ -112,7 +112,7 @@ describe('Kafka Producer', () => {
     expect(sendStub.args[0][2] instanceof Buffer).to.be.true;
   });
 
-  it.only('should terminate cleanly if the producer is connected', async () => {
+  it('should terminate cleanly if the producer is connected', async () => {
     const registry = new Registry();
     const p = new Producer(
       {

--- a/packages/steveo/test/producer/kafka_test.ts
+++ b/packages/steveo/test/producer/kafka_test.ts
@@ -111,4 +111,37 @@ describe('Kafka Producer', () => {
     await p.send('test-topic', JSON.stringify({ a: 'payload', b: '¼' }));
     expect(sendStub.args[0][2] instanceof Buffer).to.be.true;
   });
+
+  it.only('should terminate cleanly if the producer is connected', async () => {
+    const registry = new Registry();
+    const p = new Producer(
+      {
+        engine: 'kafka',
+        bootstrapServers: 'kafka:9200',
+        securityProtocol: 'plaintext',
+        tasksPath: '',
+      },
+      registry
+    );
+    sandbox.stub(p.producer, 'isConnected').resolves(true);
+    const disconnectStub = sandbox.stub(p.producer, 'disconnect');
+    await p.stop();
+    expect(disconnectStub.callCount).to.equal(1);
+  });
+
+  it('should terminate cleanly if the producer is not connected', async () => {
+    const registry = new Registry();
+    const p = new Producer(
+      {
+        engine: 'kafka',
+        bootstrapServers: 'kafka:9200',
+        securityProtocol: 'plaintext',
+        tasksPath: '',
+      },
+      registry
+    );
+    const disconnectStub = sandbox.spy(p.producer, 'disconnect');
+    await p.stop();
+    expect(disconnectStub.callCount).to.equal(0);
+  });
 });


### PR DESCRIPTION
#### Description

Adds a check to see if the kafka producer is connected before disconnecting. This prevents an error being thrown for an unconnected producer getting a disconnect call.

