### PR TITLE
Adds helper method for generating n next occurrences

### DIFF
--- a/.changeset/famous-brooms-hunt.md
+++ b/.changeset/famous-brooms-hunt.md
@@ -1,6 +1,6 @@
 ---
-"@steveojs/scheduler-sequelize": major
-"@steveojs/scheduler-prisma": major
+"@steveojs/scheduler-sequelize": minor
+"@steveojs/scheduler-prisma": minor
 ---
 
-Added helper method to generate n next occurences
+Deprecated computeNextRunAt method replaced by computeNextRun that leverages on the new rrule-rust library. Added computeNextRuns that generates n next occurences also leveraging on the new rrule-rust library. 

--- a/.changeset/famous-brooms-hunt.md
+++ b/.changeset/famous-brooms-hunt.md
@@ -1,0 +1,6 @@
+---
+"@steveojs/scheduler-sequelize": major
+"@steveojs/scheduler-prisma": major
+---
+
+Added helper method to generate n next occurences

--- a/packages/scheduler-prisma/README.md
+++ b/packages/scheduler-prisma/README.md
@@ -1,0 +1,35 @@
+# steveo-scheduler-prisma
+
+A scheduler provider for [steveo](https://github.com/ordermentum/steveo) library.
+
+- Computes next run of a schedule
+- Computes n next run occurences of a schedule
+
+### What's new
+Version 7.1.0
+
+- Deprecated `computeNextRunAt` method replaced by `computeNextRun` that uses the rrule-rust library
+    #### Usage
+    ```
+    computeNextRunAt(interval, 'UTC') ---> OLD
+    computeNextRun(interval, { timezone: 'UTC', startDate: moment().toISOString() }) ---> NEW
+    ```
+- `computeNextRun` will check if the rule is valid, convert to a valid rule if not and return a single run date in ISO string
+    #### Parameters
+     - interval: should be an [iCal](https://icalendar.org/rrule-tool.html) rrule string
+     - timezone: timezone to compute the next run, UTC by default
+     - startDate: start date to compute the next run, now() by default
+    #### Usage
+    ```
+    computeNextRun(interval, { timezone: 'UTC', startDate: moment().toISOString() })
+    ```
+- `computeNextRuns` similar to `computeNextRun` but will return n next run dates in ISO string
+    #### Parameters
+     - interval: should be an [iCal](https://icalendar.org/rrule-tool.html) rrule string
+     - timezone: timezone to compute the next run, UTC by default
+     - startDate: start date to compute the next run, now() by default
+     - count: number of occurrences, 1 by default max of 30
+    #### Usage
+    ```
+    computeNextRuns(interval, { timezone: 'Australia/Sydney', startDate: moment().toISOString(), count: 5 })
+    ```

--- a/packages/scheduler-prisma/src/helpers.ts
+++ b/packages/scheduler-prisma/src/helpers.ts
@@ -17,39 +17,88 @@ const SIX_MONTHS_IN_MS = 15778476000;
 export const isHealthy = (heartbeat: number, timeout: number) =>
   new Date().getTime() - timeout < heartbeat;
 
+const getValidRule = (recurrence: string, timezone?: string) => {
+  const isICalRule = recurrence.includes('DTSTART');
+  if (isICalRule) return recurrence;
+
+  let derivedTimezone = timezone ?? 'Australia/Sydney';
+  const rule = recurrence
+    .split(';')
+    .filter(b => {
+      const [key, value] = b.split('=');
+      if (key === 'TZID') {
+        derivedTimezone = value;
+      }
+      return key !== 'TZID';
+    })
+    .join(';');
+
+  const timeISO8601 = moment().tz(derivedTimezone).format('YYYYMMDDTHHmmss');
+  return `DTSTART;TZID=${derivedTimezone}:${timeISO8601}\nRRULE:${rule}`;
+};
+
 // interval should be iCal String.
-export const computeNextRunAt = (
+export const computeNextRun = (
   interval: string,
-  timezone = 'UTC'
+  {
+    /**
+     * @description Timezone to compute the next run at
+     * @default UTC
+     */
+    timezone = 'UTC',
+    /**
+     * @description Start date to compute the next run at
+     * @default now()
+     */
+    startDate = moment().toISOString(),
+  } = {}
 ): string => {
   if (!interval) {
-    throw new Error('Invalid interval argument supplied to computeNextRunAt');
+    throw new Error('Need a valid interval to compute next run at');
   }
 
-  const isValidRule = interval.includes('DTSTART');
+  const rule = getValidRule(interval, timezone);
+  const rrule = RRuleSet.parse(rule);
+  const start = moment(startDate).valueOf();
+  const end = moment(start).add(SIX_MONTHS_IN_MS, 'ms').valueOf();
+  return new Date(rrule.between(start, end, true)[0]).toISOString();
+};
 
-  if (!isValidRule) {
-    const rule = interval
-      .split(';')
-      .filter(b => !b.includes('TZID'))
-      .join(';');
-
-    const timeISO8601 = moment().tz(timezone).format('YYYYMMDDTHHmmss');
-    const rrule = RRuleSet.parse(
-      `DTSTART;TZID=${timezone}:${timeISO8601}\nRRULE:${rule}\nEXDATE;TZID=${timezone}:${timeISO8601}`
-    );
-    return new Date(rrule.all(1)[0]).toISOString();
+export const computeNextRuns = (
+  interval: string,
+  {
+    /**
+     * @description Timezone to compute the next run at
+     * @default UTC
+     */
+    timezone = 'UTC',
+    /**
+     * @description Start date to compute the next run at
+     * @default now()
+     */
+    startDate = moment().toISOString(),
+    /**
+     * @description The number of runs to compute
+     * @default 1
+     * @max 10
+     */
+    count = 1,
+  } = {}
+): string[] => {
+  if (!interval) {
+    throw new Error('Need a valid interval to compute next run at');
   }
 
-  const rrule = RRuleSet.parse(interval);
+  const rule = getValidRule(interval, timezone);
+  const rrule = RRuleSet.parse(rule);
+  const runCount = Math.min(count, 30);
 
-  return new Date(
-    rrule.between(
-      new Date().getTime(),
-      new Date().getTime() + SIX_MONTHS_IN_MS,
-      true
-    )[0]
-  ).toISOString();
+  const start = moment(startDate).valueOf();
+  const end = moment(start).add(SIX_MONTHS_IN_MS, 'ms').valueOf();
+  return rrule
+    .between(start, end, true)
+    .slice(0, runCount)
+    .map(run => new Date(run).toISOString());
 };
 
 /**
@@ -74,7 +123,9 @@ export const resetJob = async (
   job: Job,
   events: TypedEventEmitter<Events>
 ) => {
-  const nextRunAt = computeNextRunAt(job.repeatInterval, job.timezone);
+  const nextRunAt = computeNextRun(job.repeatInterval, {
+    timezone: job.timezone,
+  });
   events.emit('reset', job, nextRunAt);
   return client.job.update({
     // @ts-expect-error namespace is an optional feature
@@ -206,7 +257,9 @@ const updateFinishTask = async (
         : { id },
     });
   }
-  const nextRunAt = computeNextRunAt(job.repeatInterval, job.timezone);
+  const nextRunAt = computeNextRun(job.repeatInterval, {
+    timezone: job.timezone,
+  });
   await client.job.update({
     where: namespace
       ? // @ts-expect-error namespace is an optional feature

--- a/packages/scheduler-prisma/src/helpers.ts
+++ b/packages/scheduler-prisma/src/helpers.ts
@@ -37,56 +37,29 @@ const getValidRule = (recurrence: string, timezone?: string) => {
   return `DTSTART;TZID=${derivedTimezone}:${timeISO8601}\nRRULE:${rule}`;
 };
 
-// interval should be iCal String.
-export const computeNextRun = (
-  interval: string,
-  {
-    /**
-     * @description Timezone to compute the next run at
-     * @default UTC
-     */
-    timezone = 'UTC',
-    /**
-     * @description Start date to compute the next run at
-     * @default now()
-     */
-    startDate = moment().toISOString(),
-  } = {}
-): string => {
-  if (!interval) {
-    throw new Error('Need a valid interval to compute next run at');
-  }
-
-  const rule = getValidRule(interval, timezone);
-  const rrule = RRuleSet.parse(rule);
-  const start = moment(startDate).valueOf();
-  const end = moment(start).add(SIX_MONTHS_IN_MS, 'ms').valueOf();
-  return new Date(rrule.between(start, end, true)[0]).toISOString();
-};
-
 export const computeNextRuns = (
   interval: string,
   {
     /**
-     * @description Timezone to compute the next run at
+     * @description Timezone to compute the next runs
      * @default UTC
      */
     timezone = 'UTC',
     /**
-     * @description Start date to compute the next run at
+     * @description Start date to compute the next runs
      * @default now()
      */
     startDate = moment().toISOString(),
     /**
      * @description The number of runs to compute
      * @default 1
-     * @max 10
+     * @max 30
      */
     count = 1,
   } = {}
 ): string[] => {
   if (!interval) {
-    throw new Error('Need a valid interval to compute next run at');
+    throw new Error('Need a valid interval to compute next runs');
   }
 
   const rule = getValidRule(interval, timezone);
@@ -99,6 +72,35 @@ export const computeNextRuns = (
     .between(start, end, true)
     .slice(0, runCount)
     .map(run => new Date(run).toISOString());
+};
+
+// interval should be iCal String.
+// This function should be in sync with packages/scheduler-sequelize/src/helpers.ts
+export const computeNextRun = (
+  interval: string,
+  {
+    /**
+     * @description Timezone to compute the next run
+     * @default UTC
+     */
+    timezone = 'UTC',
+    /**
+     * @description Start date to compute the next run
+     * @default now()
+     */
+    startDate = moment().toISOString(),
+  } = {}
+): string => {
+  if (!interval) {
+    throw new Error('Need a valid interval to compute next run');
+  }
+
+  const [nextRun] = computeNextRuns(interval, {
+    timezone,
+    startDate,
+    count: 1,
+  });
+  return nextRun;
 };
 
 /**

--- a/packages/scheduler-prisma/test/helpers_test.ts
+++ b/packages/scheduler-prisma/test/helpers_test.ts
@@ -14,7 +14,7 @@ describe('helpers', () => {
 
   afterEach(() => {
     process.env.TZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    if(clock) clock.restore();
+    if (clock) clock.restore();
     sandbox.restore();
   });
 
@@ -27,13 +27,37 @@ describe('helpers', () => {
 
     // List of recurrence rules to test
     // comparator that returns boolean
-    ([
-      ['FREQ=HOURLY;INTERVAL=1', 'UTC', (m: Moment) => moment().tz('utc').diff(m, 'minutes') === -59],
-      ['FREQ=WEEKLY;INTERVAL=1;BYDAY=MO;BYHOUR=16;BYMINUTE=40', { timezone: 'Australia/Sydney'}, (m: Moment) => m.day() === 1 && m.hour() === 16 && m.minute() === 40 && ['+1100', '+1000'].some(x => x === m.format('ZZ'))],
-      ['FREQ=WEEKLY;INTERVAL=1;BYDAY=WE;BYHOUR=17;BYMINUTE=40;BYSECOND=0', { timezone: 'Australia/Sydney'}, (m: Moment) => m.day() === 3 && m.hour() === 17 && m.minute() === 40 && m.second() === 0  && ['+1100', '+1000'].some(x => x === m.format('ZZ'))],
-    ] as [string, string, (m: Moment) => boolean][]).forEach( ([rule, timezone, comparator]) => {
+    (
+      [
+        [
+          'FREQ=HOURLY;INTERVAL=1',
+          'UTC',
+          (m: Moment) => moment().tz('utc').diff(m, 'minutes') === -59,
+        ],
+        [
+          'FREQ=WEEKLY;INTERVAL=1;BYDAY=MO;BYHOUR=16;BYMINUTE=40',
+          'Australia/Sydney',
+          (m: Moment) =>
+            m.day() === 1 &&
+            m.hour() === 16 &&
+            m.minute() === 40 &&
+            ['+1100', '+1000'].some(x => x === m.format('ZZ')),
+        ],
+        [
+          'FREQ=WEEKLY;INTERVAL=1;BYDAY=WE;BYHOUR=17;BYMINUTE=40;BYSECOND=0',
+          'Australia/Sydney',
+          (m: Moment) =>
+            m.day() === 3 &&
+            m.hour() === 17 &&
+            m.minute() === 40 &&
+            m.second() === 0 &&
+            ['+1100', '+1000'].some(x => x === m.format('ZZ')),
+        ],
+      ] as [string, string, (m: Moment) => boolean][]
+    ).forEach(([rule, timezone, comparator]) => {
       it(`Calculates the next date for rule ${rule} correctly`, () => {
-        expect(comparator(moment(computeNextRun(rule, { timezone })))).to.be.true;
+        expect(comparator(moment(computeNextRun(rule, { timezone })))).to.be
+          .true;
       });
     });
 
@@ -41,45 +65,73 @@ describe('helpers', () => {
       // set the current date to a thursday
       // At AEDT this will be 2024-01-25T03:00:00+11:00
       clock = sinon.useFakeTimers(new Date('2024-01-24T16:00:00Z').getTime());
-      const rule = 'FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
-      const nextDate = moment(computeNextRun(rule, { timezone: 'Australia/Sydney'}));
-      expect([nextDate.date(), nextDate.month(), nextDate.year()]).to.eqls([7, 1, 2024]); 
+      const rule =
+        'FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
+      const nextDate = moment(
+        computeNextRun(rule, { timezone: 'Australia/Sydney' })
+      );
+      expect([nextDate.date(), nextDate.month(), nextDate.year()]).to.eqls([
+        7, 1, 2024,
+      ]);
     });
 
     it('Can handle DST switchover with a rrule', () => {
       // set the current date to 6th April 2024
       // At AEDT this will be 2024-04-06T03:00:00+11:00
       clock = sinon.useFakeTimers(new Date('2024-04-05T16:00:00Z').getTime());
-      const rule = 'FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
-      const nextDate = computeNextRun(rule, { timezone: 'Australia/Sydney'});
+      const rule =
+        'FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
+      const nextDate = computeNextRun(rule, { timezone: 'Australia/Sydney' });
       expect(nextDate).to.eqls('2024-04-17T02:00:00.000Z');
       const parsed = moment(nextDate);
-      expect([parsed.date(), parsed.month(), parsed.year(), parsed.hours(), parsed.minutes(), parsed.format('ZZ')]).to.eqls([17, 3, 2024, 12, 0, '+1000']);
+      expect([
+        parsed.date(),
+        parsed.month(),
+        parsed.year(),
+        parsed.hours(),
+        parsed.minutes(),
+        parsed.format('ZZ'),
+      ]).to.eqls([17, 3, 2024, 12, 0, '+1000']);
     });
 
     it('Can handle fortnightly rrule with a dtstart', () => {
-      const rule = 'DTSTART;TZID=Australia/Sydney:20230126T030000\nRRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
+      const rule =
+        'DTSTART;TZID=Australia/Sydney:20230126T030000\nRRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
       // set the current date to a thursday
       // At AEDT this will be 2024-01-25T03:00:00+11:00
       clock = sinon.useFakeTimers(new Date('2023-01-25T16:00:00Z').getTime());
-      let nextDate = moment(computeNextRun(rule, { timezone: 'Australia/Sydney'}));
-      expect([nextDate.date(), nextDate.month(), nextDate.year()]).to.eqls([8, 1, 2023]); 
+      let nextDate = moment(
+        computeNextRun(rule, { timezone: 'Australia/Sydney' })
+      );
+      expect([nextDate.date(), nextDate.month(), nextDate.year()]).to.eqls([
+        8, 1, 2023,
+      ]);
       clock.restore();
       // After 16/02/2023, starting from 26/01/2023, the next run should be 22/02/2023
       clock = sinon.useFakeTimers(new Date('2023-02-16T16:00:00Z').getTime());
-      nextDate = moment(computeNextRun(rule, { timezone: 'Australia/Sydney'}));
-      expect([nextDate.date(), nextDate.month(), nextDate.year()]).to.eqls([22, 1, 2023]); 
+      nextDate = moment(computeNextRun(rule, { timezone: 'Australia/Sydney' }));
+      expect([nextDate.date(), nextDate.month(), nextDate.year()]).to.eqls([
+        22, 1, 2023,
+      ]);
     });
 
     it('Can handle DST switchover with a rrule with DTSTART', () => {
       // set the current date to 6th April 2024
       // At AEDT this will be 2024-04-06T03:00:00+11:00
       clock = sinon.useFakeTimers(new Date('2024-04-05T16:00:00Z').getTime());
-      const rule = 'DTSTART;TZID=Australia/Sydney:20240406T030000\nRRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
-      const nextDate = computeNextRun(rule, { timezone: 'Australia/Sydney'});
+      const rule =
+        'DTSTART;TZID=Australia/Sydney:20240406T030000\nRRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
+      const nextDate = computeNextRun(rule, { timezone: 'Australia/Sydney' });
       expect(nextDate).to.eqls('2024-04-17T02:00:00.000Z');
       const parsed = moment(nextDate);
-      expect([parsed.date(), parsed.month(), parsed.year(), parsed.hours(), parsed.minutes(), parsed.format('ZZ')]).to.eqls([17, 3, 2024, 12, 0, '+1000']);
+      expect([
+        parsed.date(),
+        parsed.month(),
+        parsed.year(),
+        parsed.hours(),
+        parsed.minutes(),
+        parsed.format('ZZ'),
+      ]).to.eqls([17, 3, 2024, 12, 0, '+1000']);
     });
   });
 

--- a/packages/scheduler-prisma/test/helpers_test.ts
+++ b/packages/scheduler-prisma/test/helpers_test.ts
@@ -1,7 +1,7 @@
 import moment, { Moment } from 'moment-timezone';
 import { expect } from 'chai';
 import sinon, { SinonSandbox, SinonFakeTimers } from 'sinon';
-import { computeNextRunAt, isHealthy } from '../src/helpers';
+import { computeNextRun, isHealthy } from '../src/helpers';
 
 describe('helpers', () => {
   let sandbox: SinonSandbox;
@@ -21,7 +21,7 @@ describe('helpers', () => {
   describe('compute next run at', () => {
     it('Calculates the next date correctly', () => {
       const every3Hours = 'FREQ=HOURLY;INTERVAL=4;BYMINUTE=0';
-      const nextDate = moment(computeNextRunAt(every3Hours));
+      const nextDate = moment(computeNextRun(every3Hours));
       expect(nextDate.diff(moment().tz('utc').minute(0), 'hours')).to.equal(3);
     });
 
@@ -29,11 +29,11 @@ describe('helpers', () => {
     // comparator that returns boolean
     ([
       ['FREQ=HOURLY;INTERVAL=1', 'UTC', (m: Moment) => moment().tz('utc').diff(m, 'minutes') === -59],
-      ['FREQ=WEEKLY;INTERVAL=1;BYDAY=MO;BYHOUR=16;BYMINUTE=40', 'Australia/Sydney', (m: Moment) => m.day() === 1 && m.hour() === 16 && m.minute() === 40 && ['+1100', '+1000'].some(x => x === m.format('ZZ'))],
-      ['FREQ=WEEKLY;INTERVAL=1;BYDAY=WE;BYHOUR=17;BYMINUTE=40;BYSECOND=0', 'Australia/Sydney', (m: Moment) => m.day() === 3 && m.hour() === 17 && m.minute() === 40 && m.second() === 0  && ['+1100', '+1000'].some(x => x === m.format('ZZ'))],
+      ['FREQ=WEEKLY;INTERVAL=1;BYDAY=MO;BYHOUR=16;BYMINUTE=40', { timezone: 'Australia/Sydney'}, (m: Moment) => m.day() === 1 && m.hour() === 16 && m.minute() === 40 && ['+1100', '+1000'].some(x => x === m.format('ZZ'))],
+      ['FREQ=WEEKLY;INTERVAL=1;BYDAY=WE;BYHOUR=17;BYMINUTE=40;BYSECOND=0', { timezone: 'Australia/Sydney'}, (m: Moment) => m.day() === 3 && m.hour() === 17 && m.minute() === 40 && m.second() === 0  && ['+1100', '+1000'].some(x => x === m.format('ZZ'))],
     ] as [string, string, (m: Moment) => boolean][]).forEach( ([rule, timezone, comparator]) => {
       it(`Calculates the next date for rule ${rule} correctly`, () => {
-        expect(comparator(moment(computeNextRunAt(rule, timezone)))).to.be.true;
+        expect(comparator(moment(computeNextRun(rule, { timezone })))).to.be.true;
       });
     });
 
@@ -42,7 +42,7 @@ describe('helpers', () => {
       // At AEDT this will be 2024-01-25T03:00:00+11:00
       clock = sinon.useFakeTimers(new Date('2024-01-24T16:00:00Z').getTime());
       const rule = 'FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
-      const nextDate = moment(computeNextRunAt(rule, 'Australia/Sydney'));
+      const nextDate = moment(computeNextRun(rule, { timezone: 'Australia/Sydney'}));
       expect([nextDate.date(), nextDate.month(), nextDate.year()]).to.eqls([7, 1, 2024]); 
     });
 
@@ -51,7 +51,7 @@ describe('helpers', () => {
       // At AEDT this will be 2024-04-06T03:00:00+11:00
       clock = sinon.useFakeTimers(new Date('2024-04-05T16:00:00Z').getTime());
       const rule = 'FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
-      const nextDate = computeNextRunAt(rule, 'Australia/Sydney');
+      const nextDate = computeNextRun(rule, { timezone: 'Australia/Sydney'});
       expect(nextDate).to.eqls('2024-04-17T02:00:00.000Z');
       const parsed = moment(nextDate);
       expect([parsed.date(), parsed.month(), parsed.year(), parsed.hours(), parsed.minutes(), parsed.format('ZZ')]).to.eqls([17, 3, 2024, 12, 0, '+1000']);
@@ -62,12 +62,12 @@ describe('helpers', () => {
       // set the current date to a thursday
       // At AEDT this will be 2024-01-25T03:00:00+11:00
       clock = sinon.useFakeTimers(new Date('2023-01-25T16:00:00Z').getTime());
-      let nextDate = moment(computeNextRunAt(rule, 'Australia/Sydney'));
+      let nextDate = moment(computeNextRun(rule, { timezone: 'Australia/Sydney'}));
       expect([nextDate.date(), nextDate.month(), nextDate.year()]).to.eqls([8, 1, 2023]); 
       clock.restore();
       // After 16/02/2023, starting from 26/01/2023, the next run should be 22/02/2023
       clock = sinon.useFakeTimers(new Date('2023-02-16T16:00:00Z').getTime());
-      nextDate = moment(computeNextRunAt(rule, 'Australia/Sydney'));
+      nextDate = moment(computeNextRun(rule, { timezone: 'Australia/Sydney'}));
       expect([nextDate.date(), nextDate.month(), nextDate.year()]).to.eqls([22, 1, 2023]); 
     });
 
@@ -76,7 +76,7 @@ describe('helpers', () => {
       // At AEDT this will be 2024-04-06T03:00:00+11:00
       clock = sinon.useFakeTimers(new Date('2024-04-05T16:00:00Z').getTime());
       const rule = 'DTSTART;TZID=Australia/Sydney:20240406T030000\nRRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
-      const nextDate = computeNextRunAt(rule, 'Australia/Sydney');
+      const nextDate = computeNextRun(rule, { timezone: 'Australia/Sydney'});
       expect(nextDate).to.eqls('2024-04-17T02:00:00.000Z');
       const parsed = moment(nextDate);
       expect([parsed.date(), parsed.month(), parsed.year(), parsed.hours(), parsed.minutes(), parsed.format('ZZ')]).to.eqls([17, 3, 2024, 12, 0, '+1000']);

--- a/packages/scheduler-sequelize/README.md
+++ b/packages/scheduler-sequelize/README.md
@@ -1,0 +1,35 @@
+# steveo-scheduler-sequelize
+
+A scheduler provider for [steveo](https://github.com/ordermentum/steveo) library.
+
+- Computes next run of a schedule
+- Computes n next run occurences of a schedule
+
+### What's new
+Version 7.1.0
+
+- Deprecated `computeNextRunAt` method replaced by `computeNextRun` that uses the rrule-rust library
+    #### Usage
+    ```
+    computeNextRunAt(interval, 'UTC') ---> OLD
+    computeNextRun(interval, { timezone: 'UTC', startDate: moment().toISOString() }) ---> NEW
+    ```
+- `computeNextRun` will check if the rule is valid, convert to a valid rule if not and return a single run date in ISO string
+    #### Parameters
+     - interval: should be an [iCal](https://icalendar.org/rrule-tool.html) rrule string
+     - timezone: timezone to compute the next run, UTC by default
+     - startDate: start date to compute the next run, now() by default
+    #### Usage
+    ```
+    computeNextRun(interval, { timezone: 'UTC', startDate: moment().toISOString() })
+    ```
+- `computeNextRuns` similar to `computeNextRun` but will return n next run dates in ISO string
+    #### Parameters
+     - interval: should be an [iCal](https://icalendar.org/rrule-tool.html) rrule string
+     - timezone: timezone to compute the next run, UTC by default
+     - startDate: start date to compute the next run, now() by default
+     - count: number of occurrences, 1 by default max of 30
+    #### Usage
+    ```
+    computeNextRuns(interval, { timezone: 'Australia/Sydney', startDate: moment().toISOString(), count: 5 })
+    ```

--- a/packages/scheduler-sequelize/src/helpers.ts
+++ b/packages/scheduler-sequelize/src/helpers.ts
@@ -37,56 +37,29 @@ const getValidRule = (recurrence: string, timezone?: string) => {
   return `DTSTART;TZID=${derivedTimezone}:${timeISO8601}\nRRULE:${rule}`;
 };
 
-// interval should be iCal String.
-export const computeNextRun = (
-  interval: string,
-  {
-    /**
-     * @description Timezone to compute the next run at
-     * @default UTC
-     */
-    timezone = 'UTC',
-    /**
-     * @description Start date to compute the next run at
-     * @default now()
-     */
-    startDate = moment().toISOString(),
-  } = {}
-): string => {
-  if (!interval) {
-    throw new Error('Need a valid interval to compute next run at');
-  }
-
-  const rule = getValidRule(interval, timezone);
-  const rrule = RRuleSet.parse(rule);
-  const start = moment(startDate).valueOf();
-  const end = moment(start).add(SIX_MONTHS_IN_MS, 'ms').valueOf();
-  return new Date(rrule.between(start, end, true)[0]).toISOString();
-};
-
 export const computeNextRuns = (
   interval: string,
   {
     /**
-     * @description Timezone to compute the next run at
+     * @description Timezone to compute the next runs
      * @default UTC
      */
     timezone = 'UTC',
     /**
-     * @description Start date to compute the next run at
+     * @description Start date to compute the next runs
      * @default now()
      */
     startDate = moment().toISOString(),
     /**
      * @description The number of runs to compute
      * @default 1
-     * @max 10
+     * @max 30
      */
     count = 1,
   } = {}
 ): string[] => {
   if (!interval) {
-    throw new Error('Need a valid interval to compute next run at');
+    throw new Error('Need a valid interval to compute next runs');
   }
 
   const rule = getValidRule(interval, timezone);
@@ -99,6 +72,35 @@ export const computeNextRuns = (
     .between(start, end, true)
     .slice(0, runCount)
     .map(run => new Date(run).toISOString());
+};
+
+// interval should be iCal String.
+// This function should be in sync with packages/scheduler-prisma/src/helpers.ts
+export const computeNextRun = (
+  interval: string,
+  {
+    /**
+     * @description Timezone to compute the next run
+     * @default UTC
+     */
+    timezone = 'UTC',
+    /**
+     * @description Start date to compute the next run
+     * @default now()
+     */
+    startDate = moment().toISOString(),
+  } = {}
+): string => {
+  if (!interval) {
+    throw new Error('Need a valid interval to compute next run');
+  }
+
+  const [nextRun] = computeNextRuns(interval, {
+    timezone,
+    startDate,
+    count: 1,
+  });
+  return nextRun;
 };
 
 /**

--- a/packages/scheduler-sequelize/src/helpers.ts
+++ b/packages/scheduler-sequelize/src/helpers.ts
@@ -34,7 +34,7 @@ const getValidRule = (recurrence: string, timezone?: string) => {
     .join(';');
 
   const timeISO8601 = moment().tz(derivedTimezone).format('YYYYMMDDTHHmmss');
-  return `DTSTART;TZID=${derivedTimezone}:${timeISO8601}\nRRULE:${rule}\nEXDATE;TZID=${derivedTimezone}:${timeISO8601}`;
+  return `DTSTART;TZID=${derivedTimezone}:${timeISO8601}\nRRULE:${rule}`;
 };
 
 // interval should be iCal String.

--- a/packages/scheduler-sequelize/src/maintenance.ts
+++ b/packages/scheduler-sequelize/src/maintenance.ts
@@ -10,7 +10,7 @@ import { JobInstance } from './models/job';
  * laggy - These are jobs that are in accepted state without transitioning to finished/dormant after 6 minutes. Fields -> queued == true && (last_finished_at < next_run_at < last_run_at < accepted_at <= (now() - 6m))
  * are restarted
  */
-import { computeNextRunAt } from './helpers';
+import { computeNextRun } from './helpers';
 
 export const resetJob = async (
   job: JobInstance,
@@ -19,7 +19,9 @@ export const resetJob = async (
   if (!job.repeatInterval) {
     return;
   }
-  const nextRunAt = computeNextRunAt(job.repeatInterval, job.timezone);
+  const nextRunAt = computeNextRun(job.repeatInterval, {
+    timezone: job.timezone,
+  });
   events.emit('reset', job.get(), nextRunAt);
   await job.update({
     queued: false,

--- a/packages/scheduler-sequelize/test/helpers_test.ts
+++ b/packages/scheduler-sequelize/test/helpers_test.ts
@@ -1,7 +1,7 @@
 import moment, { Moment } from 'moment-timezone';
 import { expect } from 'chai';
 import sinon, { SinonSandbox, SinonFakeTimers } from 'sinon';
-import { computeNextRunAt, isHealthy } from '../src/helpers';
+import { computeNextRun, isHealthy } from '../src/helpers';
 
 describe('helpers', () => {
   let sandbox: SinonSandbox;
@@ -21,7 +21,7 @@ describe('helpers', () => {
   describe('compute next run at', () => {
     it('Calculates the next date correctly', () => {
       const every3Hours = 'FREQ=HOURLY;INTERVAL=4;BYMINUTE=0';
-      const nextDate = moment(computeNextRunAt(every3Hours));
+      const nextDate = moment(computeNextRun(every3Hours));
       expect(nextDate.diff(moment().tz('utc').minute(0), 'hours')).to.equal(3);
     });
 
@@ -29,11 +29,11 @@ describe('helpers', () => {
     // comparator that returns boolean
     ([
       ['FREQ=HOURLY;INTERVAL=1', 'UTC', (m: Moment) => moment().tz('utc').diff(m, 'minutes') === -59],
-      ['FREQ=WEEKLY;INTERVAL=1;BYDAY=MO;BYHOUR=16;BYMINUTE=40', 'Australia/Sydney', (m: Moment) => m.day() === 1 && m.hour() === 16 && m.minute() === 40 && ['+1100', '+1000'].some(x => x === m.format('ZZ'))],
-      ['FREQ=WEEKLY;INTERVAL=1;BYDAY=WE;BYHOUR=17;BYMINUTE=40;BYSECOND=0', 'Australia/Sydney', (m: Moment) => m.day() === 3 && m.hour() === 17 && m.minute() === 40 && m.second() === 0  && ['+1100', '+1000'].some(x => x === m.format('ZZ'))],
+      ['FREQ=WEEKLY;INTERVAL=1;BYDAY=MO;BYHOUR=16;BYMINUTE=40', {timezone: 'Australia/Sydney'}, (m: Moment) => m.day() === 1 && m.hour() === 16 && m.minute() === 40 && ['+1100', '+1000'].some(x => x === m.format('ZZ'))],
+      ['FREQ=WEEKLY;INTERVAL=1;BYDAY=WE;BYHOUR=17;BYMINUTE=40;BYSECOND=0', {timezone: 'Australia/Sydney'}, (m: Moment) => m.day() === 3 && m.hour() === 17 && m.minute() === 40 && m.second() === 0  && ['+1100', '+1000'].some(x => x === m.format('ZZ'))],
     ] as [string, string, (m: Moment) => boolean][]).forEach( ([rule, timezone, comparator]) => {
       it(`Calculates the next date for rule ${rule} correctly`, () => {
-        expect(comparator(moment(computeNextRunAt(rule, timezone)))).to.be.true;
+        expect(comparator(moment(computeNextRun(rule, { timezone })))).to.be.true;
       });
     });
 
@@ -42,7 +42,7 @@ describe('helpers', () => {
       // At AEDT this will be 2024-01-25T03:00:00+11:00
       clock = sinon.useFakeTimers(new Date('2024-01-24T16:00:00Z').getTime());
       const rule = 'FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
-      const nextDate = moment(computeNextRunAt(rule, 'Australia/Sydney'));
+      const nextDate = moment(computeNextRun(rule, {timezone: 'Australia/Sydney'}));
       expect([nextDate.date(), nextDate.month(), nextDate.year()]).to.eqls([7, 1, 2024]); 
     });
 
@@ -51,7 +51,7 @@ describe('helpers', () => {
       // At AEDT this will be 2024-04-06T03:00:00+11:00
       clock = sinon.useFakeTimers(new Date('2024-04-05T16:00:00Z').getTime());
       const rule = 'FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
-      const nextDate = computeNextRunAt(rule, 'Australia/Sydney');
+      const nextDate = computeNextRun(rule, {timezone: 'Australia/Sydney'});
       expect(nextDate).to.eqls('2024-04-17T02:00:00.000Z');
       const parsed = moment(nextDate);
       expect([parsed.date(), parsed.month(), parsed.year(), parsed.hours(), parsed.minutes(), parsed.format('ZZ')]).to.eqls([17, 3, 2024, 12, 0, '+1000']);
@@ -62,12 +62,12 @@ describe('helpers', () => {
       // set the current date to a thursday
       // At AEDT this will be 2024-01-25T03:00:00+11:00
       clock = sinon.useFakeTimers(new Date('2023-01-25T16:00:00Z').getTime());
-      let nextDate = moment(computeNextRunAt(rule, 'Australia/Sydney'));
+      let nextDate = moment(computeNextRun(rule, {timezone: 'Australia/Sydney'}));
       expect([nextDate.date(), nextDate.month(), nextDate.year()]).to.eqls([8, 1, 2023]); 
       clock.restore();
       // After 16/02/2023, starting from 26/01/2023, the next run should be 22/02/2023
       clock = sinon.useFakeTimers(new Date('2023-02-16T16:00:00Z').getTime());
-      nextDate = moment(computeNextRunAt(rule, 'Australia/Sydney'));
+      nextDate = moment(computeNextRun(rule, {timezone: 'Australia/Sydney'}));
       expect([nextDate.date(), nextDate.month(), nextDate.year()]).to.eqls([22, 1, 2023]); 
     });
 
@@ -76,7 +76,7 @@ describe('helpers', () => {
       // At AEDT this will be 2024-04-06T03:00:00+11:00
       clock = sinon.useFakeTimers(new Date('2024-04-05T16:00:00Z').getTime());
       const rule = 'DTSTART;TZID=Australia/Sydney:20240406T030000\nRRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
-      const nextDate = computeNextRunAt(rule, 'Australia/Sydney');
+      const nextDate = computeNextRun(rule, {timezone: 'Australia/Sydney'});
       expect(nextDate).to.eqls('2024-04-17T02:00:00.000Z');
       const parsed = moment(nextDate);
       expect([parsed.date(), parsed.month(), parsed.year(), parsed.hours(), parsed.minutes(), parsed.format('ZZ')]).to.eqls([17, 3, 2024, 12, 0, '+1000']);

--- a/packages/scheduler-sequelize/test/helpers_test.ts
+++ b/packages/scheduler-sequelize/test/helpers_test.ts
@@ -14,7 +14,7 @@ describe('helpers', () => {
 
   afterEach(() => {
     process.env.TZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    if(clock) clock.restore();
+    if (clock) clock.restore();
     sandbox.restore();
   });
 
@@ -27,13 +27,37 @@ describe('helpers', () => {
 
     // List of recurrence rules to test
     // comparator that returns boolean
-    ([
-      ['FREQ=HOURLY;INTERVAL=1', 'UTC', (m: Moment) => moment().tz('utc').diff(m, 'minutes') === -59],
-      ['FREQ=WEEKLY;INTERVAL=1;BYDAY=MO;BYHOUR=16;BYMINUTE=40', {timezone: 'Australia/Sydney'}, (m: Moment) => m.day() === 1 && m.hour() === 16 && m.minute() === 40 && ['+1100', '+1000'].some(x => x === m.format('ZZ'))],
-      ['FREQ=WEEKLY;INTERVAL=1;BYDAY=WE;BYHOUR=17;BYMINUTE=40;BYSECOND=0', {timezone: 'Australia/Sydney'}, (m: Moment) => m.day() === 3 && m.hour() === 17 && m.minute() === 40 && m.second() === 0  && ['+1100', '+1000'].some(x => x === m.format('ZZ'))],
-    ] as [string, string, (m: Moment) => boolean][]).forEach( ([rule, timezone, comparator]) => {
+    (
+      [
+        [
+          'FREQ=HOURLY;INTERVAL=1',
+          'UTC',
+          (m: Moment) => moment().tz('utc').diff(m, 'minutes') === -59,
+        ],
+        [
+          'FREQ=WEEKLY;INTERVAL=1;BYDAY=MO;BYHOUR=16;BYMINUTE=40',
+          'Australia/Sydney',
+          (m: Moment) =>
+            m.day() === 1 &&
+            m.hour() === 16 &&
+            m.minute() === 40 &&
+            ['+1100', '+1000'].some(x => x === m.format('ZZ')),
+        ],
+        [
+          'FREQ=WEEKLY;INTERVAL=1;BYDAY=WE;BYHOUR=17;BYMINUTE=40;BYSECOND=0',
+          'Australia/Sydney',
+          (m: Moment) =>
+            m.day() === 3 &&
+            m.hour() === 17 &&
+            m.minute() === 40 &&
+            m.second() === 0 &&
+            ['+1100', '+1000'].some(x => x === m.format('ZZ')),
+        ],
+      ] as [string, string, (m: Moment) => boolean][]
+    ).forEach(([rule, timezone, comparator]) => {
       it(`Calculates the next date for rule ${rule} correctly`, () => {
-        expect(comparator(moment(computeNextRun(rule, { timezone })))).to.be.true;
+        expect(comparator(moment(computeNextRun(rule, { timezone })))).to.be
+          .true;
       });
     });
 
@@ -41,45 +65,73 @@ describe('helpers', () => {
       // set the current date to a thursday
       // At AEDT this will be 2024-01-25T03:00:00+11:00
       clock = sinon.useFakeTimers(new Date('2024-01-24T16:00:00Z').getTime());
-      const rule = 'FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
-      const nextDate = moment(computeNextRun(rule, {timezone: 'Australia/Sydney'}));
-      expect([nextDate.date(), nextDate.month(), nextDate.year()]).to.eqls([7, 1, 2024]); 
+      const rule =
+        'FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
+      const nextDate = moment(
+        computeNextRun(rule, { timezone: 'Australia/Sydney' })
+      );
+      expect([nextDate.date(), nextDate.month(), nextDate.year()]).to.eqls([
+        7, 1, 2024,
+      ]);
     });
 
     it('Can handle DST switchover with a rrule', () => {
       // set the current date to 6th April 2024
       // At AEDT this will be 2024-04-06T03:00:00+11:00
       clock = sinon.useFakeTimers(new Date('2024-04-05T16:00:00Z').getTime());
-      const rule = 'FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
-      const nextDate = computeNextRun(rule, {timezone: 'Australia/Sydney'});
+      const rule =
+        'FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
+      const nextDate = computeNextRun(rule, { timezone: 'Australia/Sydney' });
       expect(nextDate).to.eqls('2024-04-17T02:00:00.000Z');
       const parsed = moment(nextDate);
-      expect([parsed.date(), parsed.month(), parsed.year(), parsed.hours(), parsed.minutes(), parsed.format('ZZ')]).to.eqls([17, 3, 2024, 12, 0, '+1000']);
+      expect([
+        parsed.date(),
+        parsed.month(),
+        parsed.year(),
+        parsed.hours(),
+        parsed.minutes(),
+        parsed.format('ZZ'),
+      ]).to.eqls([17, 3, 2024, 12, 0, '+1000']);
     });
 
     it('Can handle fortnightly rrule with a dtstart', () => {
-      const rule = 'DTSTART;TZID=Australia/Sydney:20230126T030000\nRRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
+      const rule =
+        'DTSTART;TZID=Australia/Sydney:20230126T030000\nRRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
       // set the current date to a thursday
       // At AEDT this will be 2024-01-25T03:00:00+11:00
       clock = sinon.useFakeTimers(new Date('2023-01-25T16:00:00Z').getTime());
-      let nextDate = moment(computeNextRun(rule, {timezone: 'Australia/Sydney'}));
-      expect([nextDate.date(), nextDate.month(), nextDate.year()]).to.eqls([8, 1, 2023]); 
+      let nextDate = moment(
+        computeNextRun(rule, { timezone: 'Australia/Sydney' })
+      );
+      expect([nextDate.date(), nextDate.month(), nextDate.year()]).to.eqls([
+        8, 1, 2023,
+      ]);
       clock.restore();
       // After 16/02/2023, starting from 26/01/2023, the next run should be 22/02/2023
       clock = sinon.useFakeTimers(new Date('2023-02-16T16:00:00Z').getTime());
-      nextDate = moment(computeNextRun(rule, {timezone: 'Australia/Sydney'}));
-      expect([nextDate.date(), nextDate.month(), nextDate.year()]).to.eqls([22, 1, 2023]); 
+      nextDate = moment(computeNextRun(rule, { timezone: 'Australia/Sydney' }));
+      expect([nextDate.date(), nextDate.month(), nextDate.year()]).to.eqls([
+        22, 1, 2023,
+      ]);
     });
 
     it('Can handle DST switchover with a rrule with DTSTART', () => {
       // set the current date to 6th April 2024
       // At AEDT this will be 2024-04-06T03:00:00+11:00
       clock = sinon.useFakeTimers(new Date('2024-04-05T16:00:00Z').getTime());
-      const rule = 'DTSTART;TZID=Australia/Sydney:20240406T030000\nRRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
-      const nextDate = computeNextRun(rule, {timezone: 'Australia/Sydney'});
+      const rule =
+        'DTSTART;TZID=Australia/Sydney:20240406T030000\nRRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE;BYHOUR=12;BYMINUTE=0;BYSECOND=0';
+      const nextDate = computeNextRun(rule, { timezone: 'Australia/Sydney' });
       expect(nextDate).to.eqls('2024-04-17T02:00:00.000Z');
       const parsed = moment(nextDate);
-      expect([parsed.date(), parsed.month(), parsed.year(), parsed.hours(), parsed.minutes(), parsed.format('ZZ')]).to.eqls([17, 3, 2024, 12, 0, '+1000']);
+      expect([
+        parsed.date(),
+        parsed.month(),
+        parsed.year(),
+        parsed.hours(),
+        parsed.minutes(),
+        parsed.format('ZZ'),
+      ]).to.eqls([17, 3, 2024, 12, 0, '+1000']);
     });
   });
 

--- a/packages/scheduler-sequelize/test/recurrence_generators_test.ts
+++ b/packages/scheduler-sequelize/test/recurrence_generators_test.ts
@@ -1,8 +1,8 @@
 import moment, { Moment } from 'moment-timezone';
 import { expect } from 'chai';
 import sinon, { SinonSandbox, SinonFakeTimers } from 'sinon';
-import { computeNextRun } from '../../scheduler-prisma/src/helpers';
 import lunartick from 'lunartick-deprecated';
+import { computeNextRun } from '@steveojs/scheduler-prisma/src/helpers';
 
 const MAX_SKEW_MILLI_SECONDS = 60 * 1000; // Max skew b/w comparative dates
 
@@ -12,200 +12,255 @@ const MAX_SKEW_MILLI_SECONDS = 60 * 1000; // Max skew b/w comparative dates
 // 3. It does not support BYMONTHDAY=-1 (https://github.com/ordermentum/lunartick/blob/develop/src/iterator.js#L110 shifts the date by an extra month)
 // 4. It does not support multiple values for BYDAY (e.g. FREQ=WEEKLY;BYDAY=MO,WE,FR)
 // 5. It does not support BYSETPOS parameter (e.g. FREQ=DAILY;BYHOUR=8,18;BYMINUTE=30,0;BYSETPOS=1,4)
-// 6. It does not chronologically sort BY rules (e.g. Values will be different for FREQ=DAILY;BYHOUR=8,18;BYMINUTE=0,30 and FREQ=DAILY;BYHOUR=8,18;BYMINUTE=30,0 - Note the BYMINUTE prop) 
+// 6. It does not chronologically sort BY rules (e.g. Values will be different for FREQ=DAILY;BYHOUR=8,18;BYMINUTE=0,30 and FREQ=DAILY;BYHOUR=8,18;BYMINUTE=30,0 - Note the BYMINUTE prop)
 // 7. It does not support -ve BYDAY values (e.g. FREQ=MONTHLY;BYDAY=-2FR)
 
-
 const generateLunartickRecurrence = (interval: string, timezone: string) => {
-    if (!interval.includes('DTSTART')) {
-        const rule = lunartick.parse(interval);
-        rule.tzId = timezone;
-        const rrule = new lunartick(rule);
-        return rrule.getNext(new Date()).date.toISOString();
-    } else {
-        const [DTSTART, rrule] = interval.split('\nRRULE:');
-        const rule = lunartick.parse(rrule);
-        rule.tzId = timezone;
-        rule.dtStart = moment(`${DTSTART.split(':')[1]}+11:00`).toISOString();
-        return new lunartick(rule).getNext(new Date()).date.toISOString();
-    }
+  if (!interval.includes('DTSTART')) {
+    const rule = lunartick.parse(interval);
+    rule.tzId = timezone;
+    // eslint-disable-next-line new-cap
+    const rrule = new lunartick(rule);
+    return rrule.getNext(new Date()).date.toISOString();
+  }
+  const [DTSTART, rrule] = interval.split('\nRRULE:');
+  const rule = lunartick.parse(rrule);
+  rule.tzId = timezone;
+  rule.dtStart = moment(`${DTSTART.split(':')[1]}+11:00`).toISOString();
+  // eslint-disable-next-line new-cap
+  return new lunartick(rule).getNext(new Date()).date.toISOString();
 };
 
-const generateRRuleRecurrence = (interval: string, timezone: string) => {
-    return computeNextRun(interval, { timezone });
-};
+const generateRRuleRecurrence = (interval: string, timezone: string) =>
+  computeNextRun(interval, { timezone });
 
 describe('helpers', () => {
-    let sandbox: SinonSandbox;
-    let clock: SinonFakeTimers;
+  let sandbox: SinonSandbox;
+  let clock: SinonFakeTimers;
 
-    beforeEach(() => {
-        process.env.TZ = 'Australia/Sydney';
-        sandbox = sinon.createSandbox();
+  beforeEach(() => {
+    process.env.TZ = 'Australia/Sydney';
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    process.env.TZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    if (clock) clock.restore();
+    sandbox.restore();
+  });
+
+  describe('Rrule and lunartick create the same recurrence date with rules that do not have DTSTART', () => {
+    it('17th of every other month', () => {
+      const rule = 'FREQ=MONTHLY;BYMONTHDAY=17;INTERVAL=1';
+      clock = sinon.useFakeTimers(new Date('2024-01-24T16:00:00Z').getTime());
+      const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
+      const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
+      expect(
+        Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())
+      ).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
     });
-
-    afterEach(() => {
-        process.env.TZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
-        if (clock) clock.restore();
-        sandbox.restore();
-    })
-
-    describe('Rrule and lunartick create the same recurrence date with rules that do not have DTSTART', () => {
-        it('17th of every other month', () => {
-            const rule = 'FREQ=MONTHLY;BYMONTHDAY=17;INTERVAL=1';
-            clock = sinon.useFakeTimers(new Date('2024-01-24T16:00:00Z').getTime());
-            const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
-            const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
-            expect(Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
-        });
-        it('every Thursday', () => {
-            const rule = 'FREQ=WEEKLY;BYDAY=TH;INTERVAL=1';
-            clock = sinon.useFakeTimers(new Date('2024-01-24T16:00:00Z').getTime());
-            const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
-            const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
-            expect(Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
-        });
-        it('every monday', () => {
-            const rule = 'FREQ=WEEKLY;BYDAY=MO';
-            clock = sinon.useFakeTimers(new Date('2024-01-24T16:00:00Z').getTime());
-            const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
-            const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
-            expect(Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
-        });
-        it('daily at 08:30 and 18:00', () => {
-            const rule = 'FREQ=DAILY;BYHOUR=8,18;BYMINUTE=0,30';
-            clock = sinon.useFakeTimers(new Date('2024-01-24T16:00:00Z').getTime());
-            const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
-            const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
-            expect(Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
-        });
+    it('every Wednesday', () => {
+      const rule = 'FREQ=WEEKLY;BYDAY=WE;INTERVAL=1';
+      clock = sinon.useFakeTimers(new Date('2024-01-24T16:00:00Z').getTime());
+      const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
+      const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
+      expect(
+        Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())
+      ).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
     });
-
-    describe('Rrule and lunartick create the same recurrence date with rules that have DTSTART', () => {
-        it('17th of every other month', () => {
-            const rule = 'DTSTART;TZID=Australia/Sydney:20240120T030000\nRRULE:FREQ=MONTHLY;BYMONTHDAY=17;INTERVAL=1;BYHOUR=16;BYMINUTE=0;BYSECOND=0';
-            clock = sinon.useFakeTimers(new Date('2024-01-24T16:00:00Z').getTime());
-            const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
-            const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
-            expect(Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
-        });
-        it('every Thursday', () => {
-            const rule = 'DTSTART;TZID=Australia/Sydney:20240120T030000\nRRULE:FREQ=WEEKLY;BYDAY=TH;INTERVAL=1;BYHOUR=16;BYMINUTE=0;BYSECOND=0';
-            clock = sinon.useFakeTimers(new Date('2024-01-24T16:00:00Z').getTime());
-            const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
-            const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
-            expect(Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
-        });
-        it('every monday', () => {
-            const rule = 'DTSTART;TZID=Australia/Sydney:20240120T030000\nRRULE:FREQ=WEEKLY;BYDAY=MO;BYHOUR=16;BYMINUTE=0;BYSECOND=0';
-            clock = sinon.useFakeTimers(new Date('2024-01-24T16:00:00Z').getTime());
-            const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
-            const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
-            expect(Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
-        });
-        it('daily at 08:30 and 18:00', () => {
-            const rule = 'DTSTART;TZID=Australia/Sydney:20240120T030000\nRRULE:FREQ=DAILY;BYHOUR=8,18;BYMINUTE=0,30;BYSECOND=0';
-            clock = sinon.useFakeTimers(new Date('2024-01-24T16:00:00Z').getTime());
-            const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
-            const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
-            expect(Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
-        });
+    it('every monday', () => {
+      const rule = 'FREQ=WEEKLY;BYDAY=MO';
+      clock = sinon.useFakeTimers(new Date('2024-01-24T16:00:00Z').getTime());
+      const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
+      const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
+      expect(
+        Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())
+      ).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
     });
-
-    describe('Rrule supported rules', () => {
-        it('Every other thursday respecting start date', () => {
-            const rule = 'DTSTART;TZID=Australia/Sydney:20240120T030000\nRRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=TH';
-            clock = sinon.useFakeTimers(new Date('2024-02-01T16:00:00Z').getTime());
-            const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
-            expect(rrule).to.eqls('2024-02-14T16:00:00.000Z');
-        });
+    it('daily at 08:30 and 18:00', () => {
+      const rule = 'FREQ=DAILY;BYHOUR=8,18;BYMINUTE=0,30';
+      clock = sinon.useFakeTimers(new Date('2024-01-24T16:00:00Z').getTime());
+      const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
+      const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
+      expect(
+        Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())
+      ).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
     });
+  });
 
-    describe('Rrule and lunartick create the same recurrence date for rules with date crossing DST thresholds', () => {
-        describe('DST ending', () => {
-            it('17th of every other month', () => {
-                const rule = 'FREQ=MONTHLY;BYMONTHDAY=17;INTERVAL=1;BYHOUR=17';
-                clock = sinon.useFakeTimers(new Date('2024-04-06T14:00:00.000Z').getTime());
-                const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
-                const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
-                expect(Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
-            });
-            it('every Thursday', () => {
-                const rule = 'FREQ=WEEKLY;BYDAY=TH;INTERVAL=1;BYHOUR=17';
-                clock = sinon.useFakeTimers(new Date('2024-04-06T14:00:00.000Z').getTime());
-                const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
-                const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
-                expect(Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
-            });
-            it('every monday', () => {
-                const rule = 'FREQ=WEEKLY;BYDAY=MO;BYHOUR=17';
-                clock = sinon.useFakeTimers(new Date('2024-04-06T14:00:00.000Z').getTime());
-                const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
-                const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
-                expect(Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
-            });
-            it('daily at 08:30 and 18:00', () => {
-                const rule = 'FREQ=DAILY;BYHOUR=8,18;BYMINUTE=0,30';
-                clock = sinon.useFakeTimers(new Date('2024-04-06T14:00:00.000Z').getTime());
-                const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
-                const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
-                expect(Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
-            });
-        });
-        describe('DST start', () => {
-            it('17th of every other month', () => {
-                const rule = 'FREQ=MONTHLY;BYMONTHDAY=17;INTERVAL=1;BYHOUR=17';
-                clock = sinon.useFakeTimers(new Date('2024-10-05T15:00:00.000Z').getTime());
-                const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
-                const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
-                expect(Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
-            });
-            it('every Thursday', () => {
-                const rule = 'FREQ=WEEKLY;BYDAY=TH;INTERVAL=1;BYHOUR=17';
-                clock = sinon.useFakeTimers(new Date('2024-10-05T15:00:00.000Z').getTime());
-                const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
-                const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
-                expect(Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
-            });
-            it('every monday', () => {
-                const rule = 'FREQ=WEEKLY;BYDAY=MO;BYHOUR=17';
-                clock = sinon.useFakeTimers(new Date('2024-10-05T15:00:00.000Z').getTime());
-                const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
-                const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
-                expect(Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
-            });
-            it('daily at 08:30 and 18:00', () => {
-                const rule = 'FREQ=DAILY;BYHOUR=8,18;BYMINUTE=0,30';
-                clock = sinon.useFakeTimers(new Date('2024-10-05T15:00:00.000Z').getTime());
-                const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
-                const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
-                expect(Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
-            });
-        });
+  describe('Rrule and lunartick create the same recurrence date with rules that have DTSTART', () => {
+    it('17th of every other month', () => {
+      const rule =
+        'DTSTART;TZID=Australia/Sydney:20240120T030000\nRRULE:FREQ=MONTHLY;BYMONTHDAY=17;INTERVAL=1;BYHOUR=16;BYMINUTE=0;BYSECOND=0';
+      clock = sinon.useFakeTimers(new Date('2024-01-24T16:00:00Z').getTime());
+      const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
+      const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
+      expect(
+        Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())
+      ).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
     });
+    it('every Thursday', () => {
+      const rule =
+        'DTSTART;TZID=Australia/Sydney:20240120T030000\nRRULE:FREQ=WEEKLY;BYDAY=TH;INTERVAL=1;BYHOUR=16;BYMINUTE=0;BYSECOND=0';
+      clock = sinon.useFakeTimers(new Date('2024-01-24T16:00:00Z').getTime());
+      const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
+      const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
+      expect(
+        Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())
+      ).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
+    });
+    it('every monday', () => {
+      const rule =
+        'DTSTART;TZID=Australia/Sydney:20240120T030000\nRRULE:FREQ=WEEKLY;BYDAY=MO;BYHOUR=16;BYMINUTE=0;BYSECOND=0';
+      clock = sinon.useFakeTimers(new Date('2024-01-24T16:00:00Z').getTime());
+      const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
+      const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
+      expect(
+        Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())
+      ).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
+    });
+    it('daily at 08:30 and 18:00', () => {
+      const rule =
+        'DTSTART;TZID=Australia/Sydney:20240120T030000\nRRULE:FREQ=DAILY;BYHOUR=8,18;BYMINUTE=0,30;BYSECOND=0';
+      clock = sinon.useFakeTimers(new Date('2024-01-24T16:00:00Z').getTime());
+      const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
+      const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
+      expect(
+        Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())
+      ).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
+    });
+  });
 
-    describe('Lunartick and rrule differences', () => {
-        [
-            'FREQ=MONTHLY;BYMONTHDAY=17;INTERVAL=2',
-            'FREQ=WEEKLY;BYDAY=TH;INTERVAL=2',
-            'FREQ=WEEKLY;BYMONTHDAY=-1;INTERVAL=2',
-            'FREQ=WEEKLY;BYDAY=MO,WE,FR',
-            'FREQ=DAILY;BYHOUR=8,18;BYMINUTE=30,0;BYSETPOS=1,4',
-            'FREQ=DAILY;BYHOUR=8,18;BYMINUTE=30,0',
-            'FREQ=MONTHLY;BYDAY=-2FR',
-        ].forEach(rule => {
-            it(`Rule: ${rule}`, () => {
-                clock = sinon.useFakeTimers(new Date('2024-01-24T16:00:00Z').getTime());
-                let lunartick;
-                try {
-                    lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
-                } catch (e) {
-                    lunartick = null;
-                }
-                const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
-                if (lunartick === null) expect(rrule).to.not.be.null;
-                else expect(Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())).to.be.greaterThan(MAX_SKEW_MILLI_SECONDS);
-            });
-        });
+  describe('Rrule supported rules', () => {
+    it('Every other thursday respecting start date', () => {
+      const rule =
+        'DTSTART;TZID=Australia/Sydney:20240120T030000\nRRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=TH';
+      clock = sinon.useFakeTimers(new Date('2024-02-01T16:00:00Z').getTime());
+      const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
+      expect(rrule).to.eqls('2024-02-14T16:00:00.000Z');
     });
+  });
+
+  describe('Rrule and lunartick create the same recurrence date for rules with date crossing DST thresholds', () => {
+    describe('DST ending', () => {
+      it('17th of every other month', () => {
+        const rule = 'FREQ=MONTHLY;BYMONTHDAY=17;INTERVAL=1;BYHOUR=17';
+        clock = sinon.useFakeTimers(
+          new Date('2024-04-06T14:00:00.000Z').getTime()
+        );
+        const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
+        const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
+        expect(
+          Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())
+        ).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
+      });
+      it('every Thursday', () => {
+        const rule = 'FREQ=WEEKLY;BYDAY=TH;INTERVAL=1;BYHOUR=17';
+        clock = sinon.useFakeTimers(
+          new Date('2024-04-06T14:00:00.000Z').getTime()
+        );
+        const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
+        const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
+        expect(
+          Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())
+        ).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
+      });
+      it('every monday', () => {
+        const rule = 'FREQ=WEEKLY;BYDAY=MO;BYHOUR=17';
+        clock = sinon.useFakeTimers(
+          new Date('2024-04-06T14:00:00.000Z').getTime()
+        );
+        const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
+        const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
+        expect(
+          Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())
+        ).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
+      });
+      it('daily at 08:30 and 18:00', () => {
+        const rule = 'FREQ=DAILY;BYHOUR=8,18;BYMINUTE=0,30';
+        clock = sinon.useFakeTimers(
+          new Date('2024-04-06T14:00:00.000Z').getTime()
+        );
+        const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
+        const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
+        expect(
+          Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())
+        ).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
+      });
+    });
+    describe('DST start', () => {
+      it('17th of every other month', () => {
+        const rule = 'FREQ=MONTHLY;BYMONTHDAY=17;INTERVAL=1;BYHOUR=17';
+        clock = sinon.useFakeTimers(
+          new Date('2024-10-05T15:00:00.000Z').getTime()
+        );
+        const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
+        const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
+        expect(
+          Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())
+        ).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
+      });
+      it('every Thursday', () => {
+        const rule = 'FREQ=WEEKLY;BYDAY=TH;INTERVAL=1;BYHOUR=17';
+        clock = sinon.useFakeTimers(
+          new Date('2024-10-05T15:00:00.000Z').getTime()
+        );
+        const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
+        const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
+        expect(
+          Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())
+        ).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
+      });
+      it('every monday', () => {
+        const rule = 'FREQ=WEEKLY;BYDAY=MO;BYHOUR=17';
+        clock = sinon.useFakeTimers(
+          new Date('2024-10-05T15:00:00.000Z').getTime()
+        );
+        const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
+        const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
+        expect(
+          Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())
+        ).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
+      });
+      it('daily at 08:30 and 18:00', () => {
+        const rule = 'FREQ=DAILY;BYHOUR=8,18;BYMINUTE=0,30';
+        clock = sinon.useFakeTimers(
+          new Date('2024-10-05T15:00:00.000Z').getTime()
+        );
+        const lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
+        const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
+        expect(
+          Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())
+        ).to.be.lessThan(MAX_SKEW_MILLI_SECONDS);
+      });
+    });
+  });
+
+  describe('Lunartick and rrule differences', () => {
+    [
+      'FREQ=MONTHLY;BYMONTHDAY=17;INTERVAL=2',
+      'FREQ=WEEKLY;BYDAY=TH;INTERVAL=2',
+      'FREQ=WEEKLY;BYMONTHDAY=-1;INTERVAL=2',
+      'FREQ=WEEKLY;BYDAY=MO,WE,FR',
+      'FREQ=DAILY;BYHOUR=8,18;BYMINUTE=30,0;BYSETPOS=1,4',
+      'FREQ=DAILY;BYHOUR=8,18;BYMINUTE=30,0',
+      'FREQ=MONTHLY;BYDAY=-2FR',
+    ].forEach(rule => {
+      it(`Rule: ${rule}`, () => {
+        clock = sinon.useFakeTimers(new Date('2024-01-24T16:00:00Z').getTime());
+        let lunartick;
+        try {
+          lunartick = generateLunartickRecurrence(rule, 'Australia/Sydney');
+        } catch (e) {
+          lunartick = null;
+        }
+        const rrule = generateRRuleRecurrence(rule, 'Australia/Sydney');
+        if (lunartick === null) expect(rrule).to.not.be.null;
+        else
+          expect(
+            Math.abs(moment(lunartick).valueOf() - moment(rrule).valueOf())
+          ).to.be.greaterThan(MAX_SKEW_MILLI_SECONDS);
+      });
+    });
+  });
 });

--- a/packages/scheduler-sequelize/test/recurrence_generators_test.ts
+++ b/packages/scheduler-sequelize/test/recurrence_generators_test.ts
@@ -1,7 +1,7 @@
 import moment, { Moment } from 'moment-timezone';
 import { expect } from 'chai';
 import sinon, { SinonSandbox, SinonFakeTimers } from 'sinon';
-import { computeNextRunAt } from '../../scheduler-prisma/src/helpers';
+import { computeNextRun } from '../../scheduler-prisma/src/helpers';
 import lunartick from 'lunartick-deprecated';
 
 const MAX_SKEW_MILLI_SECONDS = 60 * 1000; // Max skew b/w comparative dates
@@ -32,7 +32,7 @@ const generateLunartickRecurrence = (interval: string, timezone: string) => {
 };
 
 const generateRRuleRecurrence = (interval: string, timezone: string) => {
-    return computeNextRunAt(interval, timezone);
+    return computeNextRun(interval, { timezone });
 };
 
 describe('helpers', () => {


### PR DESCRIPTION
https://ordermentum.atlassian.net/browse/SUPPLIER-2916

- `computeNextRun` that generates a single next run
- `computeNextRuns` that generates n next occurrences. `count` = occurrences that need to be generated, default 1
- Porting of this code to prisma scheduler
- Changeset added
- Initial set of tests