### PR TITLE
[DEVOPS] Fix scheduler context unpacking issue

### DIFF
--- a/.changeset/spicy-dolphins-impress.md
+++ b/.changeset/spicy-dolphins-impress.md
@@ -1,0 +1,6 @@
+---
+"steveo": patch
+---
+
+Fix SQS consumer issue preventing message context from being unpacked.
+The code responsible for unpacking the context was accidentally removed during Steveo migration from v5 to v6.

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ dist
 .vscode/
 jsconfig.json
 
+# Jetbrains IDEs
+.idea
+
 example/docker-compose-ordermentum.yml
 
 packages/*/lib/

--- a/packages/steveo/src/consumers/sqs.ts
+++ b/packages/steveo/src/consumers/sqs.ts
@@ -33,6 +33,7 @@ class SqsRunner extends BaseRunner implements IRunner {
     this.sqs = getSqsInstance(steveo.config);
     this.pool = steveo.pool;
     this.concurrency = safeParseInt(steveo.config.workerConfig?.max ?? 1, 1);
+    this.logger.info('SQS Runner started');
   }
 
   async receive(messages: SQS.MessageList, topic: string): Promise<any> {
@@ -43,21 +44,21 @@ class SqsRunner extends BaseRunner implements IRunner {
       async message => {
         const params = JSON.parse(message.Body as string);
         await this.wrap({ topic, payload: params }, async c => {
+          this.logger.info(message, `Message received for task: ${c.topic}`);
           let resource: Resource | null = null;
+          // Not sure whether runnerContext still necessary.
           const runnerContext = getContext(c.payload);
-
           try {
             resource = await this.pool.acquire();
 
             this.registry.emit(
               'runner_receive',
               c.topic,
-              params,
+              c.payload,
               runnerContext
             );
 
             const task = this.registry.getTask(topic);
-
             const waitToCommit =
               (task?.options?.waitToCommit || this.config?.waitToCommit) ??
               false;
@@ -66,15 +67,19 @@ class SqsRunner extends BaseRunner implements IRunner {
               await this.deleteMessage(c.topic, message);
             }
 
-            this.logger.debug('Start subscribe', c.topic, params);
             if (!task) {
               this.logger.error(`Unknown Task ${c.topic}`);
               return;
             }
 
-            await task.subscribe(params, runnerContext);
-            this.logger.debug('Completed subscribe', c.topic, params);
-            const completedContext = getContext(params);
+            const { context = null, ...data } = c.payload;
+            this.logger.info(
+              { context, data },
+              `Start Subscribe to ${task.name}`
+            );
+            await task.subscribe(data, context);
+            this.logger.debug('Completed subscribe', c.topic, c.payload);
+            const completedContext = getContext(c.payload);
 
             if (waitToCommit) {
               await this.deleteMessage(c.topic, message);

--- a/packages/steveo/src/consumers/sqs.ts
+++ b/packages/steveo/src/consumers/sqs.ts
@@ -46,7 +46,6 @@ class SqsRunner extends BaseRunner implements IRunner {
         await this.wrap({ topic, payload: params }, async c => {
           this.logger.info(message, `Message received for task: ${c.topic}`);
           let resource: Resource | null = null;
-          // Not sure whether runnerContext still necessary.
           const runnerContext = getContext(c.payload);
           try {
             resource = await this.pool.acquire();
@@ -72,14 +71,12 @@ class SqsRunner extends BaseRunner implements IRunner {
               return;
             }
 
-            const { context = {} } = c.payload;
-
             this.logger.info(
-              { context, params },
+              { context: runnerContext, params },
               `Start Subscribe to ${task.name}`
             );
 
-            await task.subscribe(params, { ...context, ...runnerContext });
+            await task.subscribe(params, runnerContext);
             this.logger.debug('Completed subscribe', c.topic, c.payload);
             const completedContext = getContext(c.payload);
 

--- a/packages/steveo/src/consumers/sqs.ts
+++ b/packages/steveo/src/consumers/sqs.ts
@@ -72,12 +72,14 @@ class SqsRunner extends BaseRunner implements IRunner {
               return;
             }
 
-            const { context = null, ...data } = c.payload;
+            const { context = {} } = c.payload;
+
             this.logger.info(
-              { context, data },
+              { context, params },
               `Start Subscribe to ${task.name}`
             );
-            await task.subscribe(data, context);
+
+            await task.subscribe(params, { ...context, ...runnerContext });
             this.logger.debug('Completed subscribe', c.topic, c.payload);
             const completedContext = getContext(c.payload);
 

--- a/packages/steveo/src/lib/context.ts
+++ b/packages/steveo/src/lib/context.ts
@@ -28,15 +28,16 @@ export const getDuration = (start = undefined) => {
 };
 
 export const getContext = params => {
-  const { _meta: meta } = params;
+  const { _meta: meta, context = {} } = params;
 
   if (!meta) {
-    return { duration: 0 };
+    return { ...context, duration: 0 };
   }
 
   const duration = getDuration(meta.start);
 
   return {
+    ...context,
     duration,
     traceMetadata: meta.traceMetadata,
   };

--- a/packages/steveo/test/consumer/sqs_test.ts
+++ b/packages/steveo/test/consumer/sqs_test.ts
@@ -88,6 +88,62 @@ describe('runner/sqs', () => {
     ).to.equal(2);
   });
 
+  it('should invoke callback with context if context is present in message body', async () => {
+    const subscribeStub = sandbox.stub().resolves({ some: 'success' });
+    const anotherRegistry = {
+      registeredTasks: [],
+      addNewTask: () => {},
+      removeTask: () => {},
+      getTopics: () => [],
+      getTask: () => ({
+        publish: () => {},
+        subscribe: subscribeStub,
+      }),
+      emit: sandbox.stub(),
+      events: {
+        emit: sandbox.stub(),
+      },
+    };
+
+    const log = logger({ level: 'debug' });
+    const config = {
+      engine: 'sqs' as const,
+      logger: log,
+      registry: anotherRegistry,
+    };
+
+    const steveo = new Steveo(config);
+    // @ts-ignore
+    steveo.registry = anotherRegistry;
+    // @ts-ignore
+    steveo.pool = build(anotherRegistry);
+
+    const anotherRunner = new Runner(steveo);
+
+    // @ts-ignore
+    const deleteMessageStub = sandbox
+      .stub(anotherRunner.sqs, 'deleteMessage')
+      // @ts-ignore
+      .returns({ promise: async () => {} });
+
+    const inputContext = { contextKey: 'contextValue' };
+    await anotherRunner.receive(
+      [
+        {
+          ReceiptHandle: v4(),
+          Body: JSON.stringify({ data: 'Hello', context: inputContext }),
+        },
+      ],
+      'a-topic'
+    );
+
+    sinon.assert.calledWith(
+      subscribeStub,
+      { data: 'Hello' },
+      inputContext
+    );
+  });
+
   it('should delete message if waitToCommit is true after processing', async () => {
     const subscribeStub = sandbox.stub().resolves({ some: 'success' });
     const anotherRegistry = {

--- a/packages/steveo/test/consumer/sqs_test.ts
+++ b/packages/steveo/test/consumer/sqs_test.ts
@@ -121,12 +121,13 @@ describe('runner/sqs', () => {
     const anotherRunner = new Runner(steveo);
 
     // @ts-ignore
-    const deleteMessageStub = sandbox
+    sandbox
       .stub(anotherRunner.sqs, 'deleteMessage')
       // @ts-ignore
       .returns({ promise: async () => {} });
 
     const inputContext = { contextKey: 'contextValue' };
+    const runnerContext = { duration: 0 };
     await anotherRunner.receive(
       [
         {
@@ -139,8 +140,8 @@ describe('runner/sqs', () => {
 
     sinon.assert.calledWith(
       subscribeStub,
-      { data: 'Hello' },
-      inputContext
+      { data: 'Hello', context: inputContext },
+      { ...inputContext, ...runnerContext }
     );
   });
 


### PR DESCRIPTION
#### Description

This PR fixes the issues of the context not being passed correctly by the SQS runner to the task handlers, and introduces a new unit test to unsure the context is correctly injected, if present in the message.

This issues was introduced during the migration from Steveo 5 to Steveo 6 when the code that handled the message unpacking was removed, probably due to some name confusion that was mixing the message context and the Steveo runtime context (Responsible for storing runtime info, such as processing startTime and endTime, etc).

----
#### Changes
_List the main changes in this PR._

----

#### Testing Instructions
_Outline the steps to test or reproduce the PR._

----

#### Screenshots
_(if appropriate, they help the reviewer visualise the changes)_

----

