### PR TITLE
Remove _meta and context from initial payload (SQS consumer)

### DIFF
--- a/packages/scheduler-prisma/src/helpers.ts
+++ b/packages/scheduler-prisma/src/helpers.ts
@@ -9,6 +9,7 @@ import {
   TaskCallback,
   JobContext,
   JobScheduler,
+  PublishableTask,
 } from './index';
 import { Properties } from './types';
 
@@ -109,8 +110,8 @@ export const computeNextRun = (
  * @returns
  */
 export const taskRunner =
-  (task: any) => (payload: Properties, context?: JobContext) =>
-    task.publish({ ...payload, context });
+  (task: PublishableTask) => (payload: Properties, context?: JobContext) =>
+    task.publish(payload, context);
 
 /**
  * Maintenace is done as follows:

--- a/packages/scheduler-prisma/src/index.ts
+++ b/packages/scheduler-prisma/src/index.ts
@@ -59,7 +59,7 @@ export type TaskArguments = {
   [key: string]: any;
   context: JobContext;
 };
-type PublishableTask = {
+export type PublishableTask = {
   publish: (...args: any) => Promise<void>;
   [key: string]: any;
 };

--- a/packages/scheduler-prisma/test/helpers_test.ts
+++ b/packages/scheduler-prisma/test/helpers_test.ts
@@ -1,7 +1,8 @@
 import moment, { Moment } from 'moment-timezone';
 import { expect } from 'chai';
 import sinon, { SinonSandbox, SinonFakeTimers } from 'sinon';
-import { computeNextRun, computeNextRuns, isHealthy } from '../src/helpers';
+import { computeNextRun, computeNextRuns, isHealthy, taskRunner } from '../src/helpers';
+import { PublishableTask } from '../src';
 
 describe('helpers', () => {
   let sandbox: SinonSandbox;
@@ -201,4 +202,23 @@ describe('helpers', () => {
         .be.false;
     });
   });
+
+  describe('taskRunner Helper', () => {
+    it('should not merge context with data before publishing message to queue', () => {
+      const publishStub = sandbox.stub();
+      const fakeTask: PublishableTask = {
+        publish: publishStub
+      };
+      const wrappedTask = taskRunner(fakeTask);
+      const payload: any = {
+        fake: 'payload',
+      }
+      const context: any = {
+        job: {}
+      }
+      wrappedTask(payload, context)
+      sinon.assert.calledWith(publishStub, payload, context);
+    });
+  });
+
 });

--- a/packages/scheduler-sequelize/src/helpers.ts
+++ b/packages/scheduler-sequelize/src/helpers.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_MAX_RESTARTS_ON_FAILURE,
   JobContext,
   JobScheduler,
+  PublishableTask,
 } from './index';
 
 import { Properties } from './types';
@@ -104,13 +105,13 @@ export const computeNextRun = (
 };
 
 /**
- * @description }
+ * @description Call publish method on Publishable Tasks passing JobContext
  * @param task {SteveoTask}
  * @returns
  */
 export const taskRunner =
-  (task: any) => (payload: Properties, context?: JobContext) =>
-    task.publish({ ...payload, context });
+  (task: PublishableTask) => (payload: Properties, context?: JobContext) =>
+    task.publish(payload, context);
 
 const updateStartTask = async (job?: JobInstance | null) => {
   if (!job) {

--- a/packages/scheduler-sequelize/src/index.ts
+++ b/packages/scheduler-sequelize/src/index.ts
@@ -53,7 +53,7 @@ export type JobContext = {
   job?: JobInstance;
 };
 
-type PublishableTask = {
+export type PublishableTask = {
   publish: (...args: any) => Promise<void>;
   [key: string]: any;
 };

--- a/packages/scheduler-sequelize/test/helpers_test.ts
+++ b/packages/scheduler-sequelize/test/helpers_test.ts
@@ -1,7 +1,8 @@
 import moment, { Moment } from 'moment-timezone';
 import { expect } from 'chai';
 import sinon, { SinonSandbox, SinonFakeTimers } from 'sinon';
-import { computeNextRun, computeNextRuns, isHealthy } from '../src/helpers';
+import { computeNextRun, computeNextRuns, isHealthy, taskRunner } from '../src/helpers';
+import { PublishableTask } from '../src/index'
 
 describe('helpers', () => {
   let sandbox: SinonSandbox;
@@ -199,6 +200,24 @@ describe('helpers', () => {
     it('fails', () => {
       expect(isHealthy(moment().subtract(5, 'hours').unix(), 60 * 1000 * 5)).to
         .be.false;
+    });
+  });
+
+  describe('taskRunner Helper', () => {
+    it('should not merge context with data before publishing message to queue', () => {
+      const publishStub = sandbox.stub();
+      const fakeTask: PublishableTask = {
+        publish: publishStub
+      };
+      const wrappedTask = taskRunner(fakeTask);
+      const payload: any = {
+        fake: 'payload',
+      }
+      const context: any = {
+        job: {}
+      }
+      wrappedTask(payload, context)
+      sinon.assert.calledWith(publishStub, payload, context);
     });
   });
 });

--- a/packages/steveo/src/consumers/sqs.ts
+++ b/packages/steveo/src/consumers/sqs.ts
@@ -46,6 +46,7 @@ class SqsRunner extends BaseRunner implements IRunner {
         await this.wrap({ topic, payload: params }, async c => {
           this.logger.info(message, `Message received for task: ${c.topic}`);
           let resource: Resource | null = null;
+          const { _meta, context, ...data } = c.payload;
           const runnerContext = getContext(c.payload);
           try {
             resource = await this.pool.acquire();
@@ -76,9 +77,9 @@ class SqsRunner extends BaseRunner implements IRunner {
               `Start Subscribe to ${task.name}`
             );
 
-            await task.subscribe(params, runnerContext);
+            await task.subscribe(data, runnerContext);
             this.logger.debug('Completed subscribe', c.topic, c.payload);
-            const completedContext = getContext(c.payload);
+            const completedContext = getContext(runnerContext);
 
             if (waitToCommit) {
               await this.deleteMessage(c.topic, message);

--- a/packages/steveo/src/consumers/sqs.ts
+++ b/packages/steveo/src/consumers/sqs.ts
@@ -46,7 +46,6 @@ class SqsRunner extends BaseRunner implements IRunner {
         await this.wrap({ topic, payload: params }, async c => {
           this.logger.info(message, `Message received for task: ${c.topic}`);
           let resource: Resource | null = null;
-          const { _meta, context, ...data } = c.payload;
           const runnerContext = getContext(c.payload);
           try {
             resource = await this.pool.acquire();
@@ -72,8 +71,11 @@ class SqsRunner extends BaseRunner implements IRunner {
               return;
             }
 
+            // const { _meta, context, ...data } = c.payload;
+            const data = { ...c.payload };
+            delete data.context;
             this.logger.info(
-              { context: runnerContext, params },
+              { context: runnerContext, data },
               `Start Subscribe to ${task.name}`
             );
 

--- a/packages/steveo/test/consumer/sqs_test.ts
+++ b/packages/steveo/test/consumer/sqs_test.ts
@@ -141,7 +141,7 @@ describe('runner/sqs', () => {
 
     sinon.assert.calledWith(
       subscribeStub,
-      { data: 'Hello', context: inputContext },
+      { data: 'Hello' },
       { ...inputContext, ...runnerContext }
     );
   });


### PR DESCRIPTION
#### Description

This PR removes the `context` attribute from the original payload data (SQS only) before sending the data to the task, if context is present in the payload.

This is to avoid confusion, since the context is injected to in the task using the context input parameters.

For instance, if the original payload is payload = `{some: 'data', context: {some: 'context'}};` 
then the task input data will be simply `{some: 'data'}`

I've checked the OM tasks, and the few who use context, at all, get if from the context input param.

----
#### Changes
_List the main changes in this PR._

----

#### Testing Instructions
_Outline the steps to test or reproduce the PR._

----

#### Screenshots
_(if appropriate, they help the reviewer visualise the changes)_

----

