### PR TITLE
[C1-1153] Modified payload parsing of received message from kafka

### DIFF
--- a/.changeset/shiny-turkeys-play.md
+++ b/.changeset/shiny-turkeys-play.md
@@ -1,0 +1,5 @@
+---
+"steveo": minor
+---
+
+Re-align kafka consumer callback payload parsing

--- a/packages/steveo/src/consumers/kafka.ts
+++ b/packages/steveo/src/consumers/kafka.ts
@@ -7,7 +7,7 @@ import Kafka, {
 import nullLogger from 'null-logger';
 import { Pool } from 'generic-pool';
 import BaseRunner from './base';
-import { getDuration } from '../lib/context';
+import { getContext, getDuration } from '../lib/context';
 import { IRunner, Logger, KafkaConfiguration } from '../common';
 import { Steveo } from '..';
 import { Resource } from '../lib/pool';
@@ -87,6 +87,7 @@ class KafkaRunner
           throw new JsonParsingError();
         }
 
+        const runnerContext = getContext(value);
         const parsed = {
           metadata: {
             ...rest,
@@ -114,9 +115,7 @@ class KafkaRunner
 
         this.logger.debug('Start subscribe', c.topic, message);
 
-        // @ts-ignore
-        const context = parsed?.context ?? null;
-        await task.subscribe(parsed, context);
+        await task.subscribe(parsed, runnerContext);
 
         if (waitToCommit) {
           this.logger.debug('committing message', message);

--- a/packages/steveo/test/consumer/kafka_test.ts
+++ b/packages/steveo/test/consumer/kafka_test.ts
@@ -299,6 +299,7 @@ describe('runner/kafka', () => {
       },
     });
     expect(context, 'expected context').to.deep.equals({
+      duration: 0,
       jobId,
     });
   });


### PR DESCRIPTION
> **Context**
- SQS and Redis expose the whole payload within the data/value, however, in kafka it stores it under value field/attribute making it hard to align the type for the expected task callback payload vs publish payload.

> **Changes**
- Store all kafka related informations on a metadata within the parsed data

This will avoid us calling steveo instead of the actual task: https://github.com/ordermentum/xero/compare/C1-1153-steveo-kafka-payload-update?expand=1

ticket: https://ordermentum.atlassian.net/browse/C1-1153

<img width="989" alt="Screen Shot 2024-07-02 at 10 57 55 AM" src="https://github.com/ordermentum/steveo/assets/108253096/d8dfe80e-474f-4a5d-b84b-f8422a184486">
