### PR TITLE
Fix scheduler merging context with data

### DIFF
--- a/.changeset/light-gifts-attack.md
+++ b/.changeset/light-gifts-attack.md
@@ -1,0 +1,19 @@
+---
+"@steveojs/scheduler-sequelize": patch
+"@steveojs/scheduler-prisma": patch
+"steveo": patch
+---
+
+Fix bug that was causing Job data and Job context to be merged instead of 
+passed separately to the task.publish method.
+
+Schedules:
+
+- Update taskRunner method to not merge the data together
+
+Steveo:
+
+ - Adjust producers to receive `data` and `context` separately and add context as a `_meta` attribute at message creation
+time, before publishing a task payload to the queue. 
+ - Adjust consumers to extract `data`  the `_meta` attribute from the message, to be passed to the Task callback 
+separate input variables.

--- a/packages/scheduler-prisma/src/helpers.ts
+++ b/packages/scheduler-prisma/src/helpers.ts
@@ -9,6 +9,7 @@ import {
   TaskCallback,
   JobContext,
   JobScheduler,
+  PublishableTask,
 } from './index';
 import { Properties } from './types';
 
@@ -109,8 +110,8 @@ export const computeNextRun = (
  * @returns
  */
 export const taskRunner =
-  (task: any) => (payload: Properties, context?: JobContext) =>
-    task.publish({ ...payload, context });
+  (task: PublishableTask) => (payload: Properties, context?: JobContext) =>
+    task.publish(payload, context);
 
 /**
  * Maintenace is done as follows:

--- a/packages/scheduler-prisma/src/index.ts
+++ b/packages/scheduler-prisma/src/index.ts
@@ -59,7 +59,7 @@ export type TaskArguments = {
   [key: string]: any;
   context: JobContext;
 };
-type PublishableTask = {
+export type PublishableTask = {
   publish: (...args: any) => Promise<void>;
   [key: string]: any;
 };

--- a/packages/scheduler-prisma/test/helpers_test.ts
+++ b/packages/scheduler-prisma/test/helpers_test.ts
@@ -1,7 +1,8 @@
 import moment, { Moment } from 'moment-timezone';
 import { expect } from 'chai';
 import sinon, { SinonSandbox, SinonFakeTimers } from 'sinon';
-import { computeNextRun, computeNextRuns, isHealthy } from '../src/helpers';
+import { computeNextRun, computeNextRuns, isHealthy, taskRunner } from '../src/helpers';
+import { PublishableTask } from '../src';
 
 describe('helpers', () => {
   let sandbox: SinonSandbox;
@@ -201,4 +202,23 @@ describe('helpers', () => {
         .be.false;
     });
   });
+
+  describe('taskRunner Helper', () => {
+    it('should not merge context with data before publishing message to queue', () => {
+      const publishStub = sandbox.stub();
+      const fakeTask: PublishableTask = {
+        publish: publishStub
+      };
+      const wrappedTask = taskRunner(fakeTask);
+      const payload: any = {
+        fake: 'payload',
+      }
+      const context: any = {
+        job: {}
+      }
+      wrappedTask(payload, context)
+      sinon.assert.calledWith(publishStub, payload, context);
+    });
+  });
+
 });

--- a/packages/scheduler-sequelize/src/helpers.ts
+++ b/packages/scheduler-sequelize/src/helpers.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_MAX_RESTARTS_ON_FAILURE,
   JobContext,
   JobScheduler,
+  PublishableTask,
 } from './index';
 
 import { Properties } from './types';
@@ -104,13 +105,13 @@ export const computeNextRun = (
 };
 
 /**
- * @description }
+ * @description Call publish method on Publishable Tasks passing JobContext
  * @param task {SteveoTask}
  * @returns
  */
 export const taskRunner =
-  (task: any) => (payload: Properties, context?: JobContext) =>
-    task.publish({ ...payload, context });
+  (task: PublishableTask) => (payload: Properties, context?: JobContext) =>
+    task.publish(payload, context);
 
 const updateStartTask = async (job?: JobInstance | null) => {
   if (!job) {

--- a/packages/scheduler-sequelize/src/index.ts
+++ b/packages/scheduler-sequelize/src/index.ts
@@ -53,7 +53,7 @@ export type JobContext = {
   job?: JobInstance;
 };
 
-type PublishableTask = {
+export type PublishableTask = {
   publish: (...args: any) => Promise<void>;
   [key: string]: any;
 };

--- a/packages/scheduler-sequelize/test/helpers_test.ts
+++ b/packages/scheduler-sequelize/test/helpers_test.ts
@@ -1,7 +1,8 @@
 import moment, { Moment } from 'moment-timezone';
 import { expect } from 'chai';
 import sinon, { SinonSandbox, SinonFakeTimers } from 'sinon';
-import { computeNextRun, computeNextRuns, isHealthy } from '../src/helpers';
+import { computeNextRun, computeNextRuns, isHealthy, taskRunner } from '../src/helpers';
+import { PublishableTask } from '../src/index'
 
 describe('helpers', () => {
   let sandbox: SinonSandbox;
@@ -199,6 +200,24 @@ describe('helpers', () => {
     it('fails', () => {
       expect(isHealthy(moment().subtract(5, 'hours').unix(), 60 * 1000 * 5)).to
         .be.false;
+    });
+  });
+
+  describe('taskRunner Helper', () => {
+    it('should not merge context with data before publishing message to queue', () => {
+      const publishStub = sandbox.stub();
+      const fakeTask: PublishableTask = {
+        publish: publishStub
+      };
+      const wrappedTask = taskRunner(fakeTask);
+      const payload: any = {
+        fake: 'payload',
+      }
+      const context: any = {
+        job: {}
+      }
+      wrappedTask(payload, context)
+      sinon.assert.calledWith(publishStub, payload, context);
     });
   });
 });

--- a/packages/steveo/src/common.ts
+++ b/packages/steveo/src/common.ts
@@ -223,7 +223,12 @@ export interface IProducer<P = any> {
   registry: IRegistry;
   producer?: any;
   initialize(topic?: string): Promise<P>;
-  getPayload(msg: any, topic: string): any;
+  getPayload<T = any>(
+    msg: T,
+    topic: string,
+    key?: string,
+    context?: { [key: string]: string }
+  ): any;
   send<T = any>(
     topic: string,
     payload: T,

--- a/packages/steveo/src/common.ts
+++ b/packages/steveo/src/common.ts
@@ -224,7 +224,12 @@ export interface IProducer<P = any> {
   producer?: any;
   initialize(topic?: string): Promise<P>;
   getPayload(msg: any, topic: string): any;
-  send<T = any>(topic: string, payload: T, key?: string): Promise<void>;
+  send<T = any>(
+    topic: string,
+    payload: T,
+    key?: string,
+    context?: { [key: string]: string }
+  ): Promise<void>;
   // FIXME: Replace T = any with Record<string, any> or an explicit list of
   // types we will handle as first-class citizens,
   // e.g. `Record<string, any> | string`.

--- a/packages/steveo/src/consumers/sqs.ts
+++ b/packages/steveo/src/consumers/sqs.ts
@@ -48,11 +48,8 @@ class SqsRunner extends BaseRunner implements IRunner {
         await this.wrap({ topic, payload: params }, async c => {
           this.logger.info(message, `Message received for task: ${c.topic}`);
           let resource: Resource | null = null;
-          const { _meta: messageContext, ...data } = c.payload;
-          const runnerContext = {
-            ...getContext(c.payload),
-            ...messageContext,
-          };
+          const { _meta: _, ...data } = c.payload;
+          const runnerContext = getContext(c.payload);
           try {
             resource = await this.pool.acquire();
 

--- a/packages/steveo/src/lib/context.ts
+++ b/packages/steveo/src/lib/context.ts
@@ -28,17 +28,16 @@ export const getDuration = (start = undefined) => {
 };
 
 export const getContext = params => {
-  const { _meta: meta, context = {} } = params;
+  const { _meta: meta } = params;
 
   if (!meta) {
-    return { ...context, duration: 0 };
+    return { duration: 0 };
   }
 
   const duration = getDuration(meta.start);
-
   return {
-    ...context,
     duration,
     traceMetadata: meta.traceMetadata,
+    ...meta,
   };
 };

--- a/packages/steveo/src/lib/context.ts
+++ b/packages/steveo/src/lib/context.ts
@@ -19,25 +19,23 @@ export const createMessageMetadata = <T = any>(message: T) => {
   return { ..._meta, hostname, timestamp, signature, start };
 };
 
-export const getDuration = (start = undefined) => {
-  const durationComponents = process.hrtime(start);
-  const seconds = durationComponents[0];
-  const nanoseconds = durationComponents[1];
-  const duration = seconds * 1000 + nanoseconds / 1e6;
-  return duration;
+export const getDuration = (
+  start: [number, number] | undefined = undefined
+): number => {
+  const durationComponents: [number, number] = process.hrtime(start);
+  const seconds: number = durationComponents[0];
+  const nanoseconds: number = durationComponents[1];
+
+  return seconds * 1000 + nanoseconds / 1e6;
 };
 
 export const getContext = params => {
-  const { _meta: meta } = params;
+  const { _meta: meta = {} } = params;
 
-  if (!meta) {
-    return { duration: 0 };
+  let duration: number = 0;
+  if (meta) {
+    duration = getDuration(meta.start);
   }
 
-  const duration = getDuration(meta.start);
-  return {
-    duration,
-    traceMetadata: meta.traceMetadata,
-    ...meta,
-  };
+  return { ...meta, duration };
 };

--- a/packages/steveo/src/producers/sqs.ts
+++ b/packages/steveo/src/producers/sqs.ts
@@ -196,7 +196,7 @@ class SqsProducer extends BaseProducer implements IProducer {
     msg: any,
     topic: string,
     key?: string,
-    context?: { [key: string]: string }
+    context: { [key: string]: string } = {}
   ): {
     MessageAttributes: any;
     MessageBody: string;

--- a/packages/steveo/src/task.ts
+++ b/packages/steveo/src/task.ts
@@ -58,14 +58,13 @@ class Task<T = any, R = any> implements ITask<T, R> {
     } else {
       params = payload;
     }
-
     try {
       // sqs calls this method twice
       await this.producer.initialize(this.topic);
       await Promise.all(
         params.map(data => {
           this.registry.emit('task_send', this.topic, data);
-          return this.producer.send(this.topic, data, context?.key);
+          return this.producer.send(this.topic, data, context?.key, context);
         })
       );
       this.registry.emit('task_success', this.topic, payload);

--- a/packages/steveo/test/consumer/sqs_test.ts
+++ b/packages/steveo/test/consumer/sqs_test.ts
@@ -194,7 +194,6 @@ describe('runner/sqs', () => {
 
     const expectedContext = {
       duration: 0,
-      traceMetadata: undefined,
       ...inputContext
     };
 


### PR DESCRIPTION
#### Description

Currently, when the scheduler picks a job to be executed and verifies whether the task at hand is of type Publishable.
If it is, the scheduler calls the Task::publish method, which accepts a task payload, and a context.
The problem is that the code that calls the `Task::publish` method (`taskRunner` helper), merges the job data and the job metadata, instead of calling `Task::publish(jobData, jobPayload). As a result, Tasks that rely on the context break since the context is now part of the payload.

To fix it, it is required to change the `taskRunner` to avoid merging the 2 objects, which causes a chain of changes in the producers to accept an optional context, and changes in the consumers to unpack the message and extract payload and metadata, before calling the task Callback function.


#### Changes
_List the main changes in this PR._

----

#### Testing Instructions
_Outline the steps to test or reproduce the PR._

----

#### Screenshots
_(if appropriate, they help the reviewer visualise the changes)_

----

