### PR TITLE
Support recurrences that have DTSTART at the end of the recurrence string

### DIFF
--- a/.changeset/three-waves-sort.md
+++ b/.changeset/three-waves-sort.md
@@ -1,0 +1,6 @@
+---
+"@steveojs/scheduler-sequelize": minor
+"@steveojs/scheduler-prisma": minor
+---
+
+Support recurrence rules that have DTSTART at the end of the recurrence string

--- a/packages/scheduler-prisma/src/helpers.ts
+++ b/packages/scheduler-prisma/src/helpers.ts
@@ -19,10 +19,11 @@ export const isHealthy = (heartbeat: number, timeout: number) =>
   new Date().getTime() - timeout < heartbeat;
 
 const getValidRule = (recurrence: string, timezone?: string) => {
-  const isICalRule = recurrence.includes('DTSTART');
+  const isICalRule = recurrence.startsWith('DTSTART');
   if (isICalRule) return recurrence;
 
-  let derivedTimezone = timezone ?? 'Australia/Sydney';
+  let derivedTimezone = timezone ?? 'UTC';
+  let dateStart = moment().toISOString();
   const rule = recurrence
     .split(';')
     .filter(b => {
@@ -30,11 +31,16 @@ const getValidRule = (recurrence: string, timezone?: string) => {
       if (key === 'TZID') {
         derivedTimezone = value;
       }
-      return key !== 'TZID';
+      if (key === 'DTSTART') {
+        dateStart = value;
+      }
+      return key !== 'TZID' && key !== 'DTSTART';
     })
     .join(';');
 
-  const timeISO8601 = moment().tz(derivedTimezone).format('YYYYMMDDTHHmmss');
+  const timeISO8601 = moment(dateStart)
+    .tz(derivedTimezone)
+    .format('YYYYMMDDTHHmmss');
   return `DTSTART;TZID=${derivedTimezone}:${timeISO8601}\nRRULE:${rule}`;
 };
 

--- a/packages/scheduler-prisma/test/helpers_test.ts
+++ b/packages/scheduler-prisma/test/helpers_test.ts
@@ -35,6 +35,15 @@ describe('helpers', () => {
       expect(nextRun.toISOString()).to.equal(nextDate.toISOString());
     });
 
+    it('Calculates the next date correctly with DTSTART at the end', () => {
+      const start = moment().tz('UTC').second(0).format('YYYYMMDDTHHmmss')
+      const daily =
+        `FREQ=DAILY;INTERVAL=1;BYMINUTE=0;TZID=UTC;DTSTART=${start}`;
+      const nextRun = moment(computeNextRun(daily));
+      const nextDate = moment(start).tz('UTC').add(1, 'day').minute(0).second(0).millisecond(0);
+      expect(nextRun.toISOString()).to.equal(nextDate.toISOString());
+    });
+
     // List of recurrence rules to test
     // comparator that returns boolean
     (
@@ -160,6 +169,16 @@ describe('helpers', () => {
       const [nextRuns] = computeNextRuns(every3Hours);
       const nextRun = moment(nextRuns);
       const nextDate = moment().tz('Australia/Sydney').add(3, 'hours').minute(0).second(0).millisecond(0);
+      expect(nextRun.toISOString()).to.equal(nextDate.toISOString());
+    });
+
+    it('Calculates the next dates correctly with DTSTART at the end', () => {
+      const start = moment().tz('UTC').second(0).format('YYYYMMDDTHHmmss')
+      const daily =
+        `FREQ=DAILY;INTERVAL=1;BYMINUTE=0;TZID=UTC;DTSTART=${start}`;
+        const [nextRuns] = computeNextRuns(daily);
+        const nextRun = moment(nextRuns);
+      const nextDate = moment(start).tz('UTC').add(1, 'day').minute(0).second(0).millisecond(0);
       expect(nextRun.toISOString()).to.equal(nextDate.toISOString());
     });
 

--- a/packages/scheduler-sequelize/src/helpers.ts
+++ b/packages/scheduler-sequelize/src/helpers.ts
@@ -19,10 +19,11 @@ export const isHealthy = (heartbeat: number, timeout: number) =>
   new Date().getTime() - timeout < heartbeat;
 
 const getValidRule = (recurrence: string, timezone?: string) => {
-  const isICalRule = recurrence.includes('DTSTART');
+  const isICalRule = recurrence.startsWith('DTSTART');
   if (isICalRule) return recurrence;
 
-  let derivedTimezone = timezone ?? 'Australia/Sydney';
+  let derivedTimezone = timezone ?? 'UTC';
+  let dateStart = moment().toISOString();
   const rule = recurrence
     .split(';')
     .filter(b => {
@@ -30,11 +31,16 @@ const getValidRule = (recurrence: string, timezone?: string) => {
       if (key === 'TZID') {
         derivedTimezone = value;
       }
-      return key !== 'TZID';
+      if (key === 'DTSTART') {
+        dateStart = value;
+      }
+      return key !== 'TZID' && key !== 'DTSTART';
     })
     .join(';');
 
-  const timeISO8601 = moment().tz(derivedTimezone).format('YYYYMMDDTHHmmss');
+  const timeISO8601 = moment(dateStart)
+    .tz(derivedTimezone)
+    .format('YYYYMMDDTHHmmss');
   return `DTSTART;TZID=${derivedTimezone}:${timeISO8601}\nRRULE:${rule}`;
 };
 

--- a/packages/scheduler-sequelize/test/helpers_test.ts
+++ b/packages/scheduler-sequelize/test/helpers_test.ts
@@ -35,6 +35,15 @@ describe('helpers', () => {
       expect(nextRun.toISOString()).to.equal(nextDate.toISOString());
     });
 
+    it('Calculates the next date correctly with DTSTART at the end', () => {
+      const start = moment().tz('UTC').second(0).format('YYYYMMDDTHHmmss')
+      const daily =
+        `FREQ=DAILY;INTERVAL=1;BYMINUTE=0;TZID=UTC;DTSTART=${start}`;
+      const nextRun = moment(computeNextRun(daily));
+      const nextDate = moment(start).tz('UTC').add(1, 'day').minute(0).second(0).millisecond(0);
+      expect(nextRun.toISOString()).to.equal(nextDate.toISOString());
+    });
+
     // List of recurrence rules to test
     // comparator that returns boolean
     (
@@ -160,6 +169,16 @@ describe('helpers', () => {
       const [nextRuns] = computeNextRuns(every3Hours);
       const nextRun = moment(nextRuns);
       const nextDate = moment().tz('Australia/Sydney').add(3, 'hours').minute(0).second(0).millisecond(0);
+      expect(nextRun.toISOString()).to.equal(nextDate.toISOString());
+    });
+
+    it('Calculates the next dates correctly with DTSTART at the end', () => {
+      const start = moment().tz('UTC').second(0).format('YYYYMMDDTHHmmss')
+      const daily =
+        `FREQ=DAILY;INTERVAL=1;BYMINUTE=0;TZID=UTC;DTSTART=${start}`;
+        const [nextRuns] = computeNextRuns(daily);
+        const nextRun = moment(nextRuns);
+      const nextDate = moment(start).tz('UTC').add(1, 'day').minute(0).second(0).millisecond(0);
       expect(nextRun.toISOString()).to.equal(nextDate.toISOString());
     });
 


### PR DESCRIPTION
#### Description

- As the PR title says have added a way to support recurrences formatted with DTSTART at the end of the string

----
#### Changes

- Use `startsWith` instead of `includes` to determine if it's an iCal rule
- If it's not an iCal rule but includes a DTSTART, format it in a way that the new library can parse it. That means moving DTSTART at the start of the string and trimming it from the rule

