### PR TITLE
[C1-1226] Added value property back into the callback payload

### DIFF
--- a/.changeset/stale-keys-argue.md
+++ b/.changeset/stale-keys-argue.md
@@ -1,0 +1,5 @@
+---
+"steveo": minor
+---
+
+Added back `value` property for backwards compatibility

--- a/packages/steveo/src/consumers/kafka.ts
+++ b/packages/steveo/src/consumers/kafka.ts
@@ -112,7 +112,13 @@ class KafkaRunner
         this.logger.debug('Start subscribe', c.topic, message);
         const runnerContext = getContext(value);
         const { _meta: _ = {}, ...data } = parsed.value;
-        await task.subscribe(data, runnerContext);
+
+        /**
+         * We still need the `value` property on the callback payload
+         * to have backwards compatibility when upgrading steveo version
+         * without needing to update every task with the new shape
+         */
+        await task.subscribe({ ...data, value: data }, runnerContext);
 
         if (waitToCommit) {
           this.logger.debug('committing message', message);

--- a/packages/steveo/test/consumer/kafka_test.ts
+++ b/packages/steveo/test/consumer/kafka_test.ts
@@ -4,7 +4,7 @@ import { randomUUID } from 'crypto';
 import Runner from '../../src/consumers/kafka';
 import { build } from '../../src/lib/pool';
 import Registry from '../../src/registry';
-import {getContext} from "../../lib/lib/context";
+import { getContext } from '../../src/lib/context';
 
 describe('runner/kafka', () => {
   let sandbox;
@@ -107,8 +107,8 @@ describe('runner/kafka', () => {
 
   it('should invoke callback when with context if context present in message', async () => {
     const subscribeStub = sinon
-    .stub()
-    .returns(Promise.resolve({ some: 'success' }));
+      .stub()
+      .returns(Promise.resolve({ some: 'success' }));
     const anotherRegistry = {
       getTask: () => ({
         publish: () => {},
@@ -150,10 +150,14 @@ describe('runner/kafka', () => {
     });
     const expectedContext: any = {
       duration: 0,
-      ...messageContext
-    }
+      ...messageContext,
+    };
     sinon.assert.called(commitOffsetStub);
-    sinon.assert.calledWith(subscribeStub, expectedPayload, expectedContext);
+    sinon.assert.calledWith(
+      subscribeStub,
+      { ...expectedPayload, value: expectedPayload },
+      expectedContext
+    );
   });
 
   it('should not commit when the subsribe fails and wait to commit config is true', async () => {
@@ -347,7 +351,10 @@ describe('runner/kafka', () => {
     expect(subscribeStub.called).to.be.true;
     const data = subscribeStub.args[0][0];
     const context = subscribeStub.args[0][1];
-    expect(data, 'expected data').to.deep.equals(messageData);
+    expect(data, 'expected data').to.deep.equals({
+      ...messageData,
+      value: messageData,
+    });
     const expectedContext = getContext(messagePayload);
     expect(context, 'expected context').to.deep.equals(expectedContext);
   });


### PR DESCRIPTION
> **Context**
- Previous version v6.4.0 had a breaking change which was augmented by renovate automatic versioning which led integrator to not sync at all. Given this issue, we want to avoid it by making the callback payload backwards compatible

> **Changes**
- Added back `value` property on the kafka callback