### PR TITLE
Increase the default termination wait count to give the process longer to complete

### DIFF
--- a/.changeset/lazy-rats-lay.md
+++ b/.changeset/lazy-rats-lay.md
@@ -1,0 +1,5 @@
+---
+"steveo": minor
+---
+
+Increase the default termination wait count to give the process longer to complete

--- a/packages/steveo/src/lib/manager.ts
+++ b/packages/steveo/src/lib/manager.ts
@@ -46,7 +46,7 @@ export class Manager {
     }
 
     let count = 0;
-    const tries = this?.steveo.config?.terminationWaitCount || 10;
+    const tries = this?.steveo.config?.terminationWaitCount || 180;
     while (!this.isTerminated) {
       if (count === tries) {
         this.forceTerminate();


### PR DESCRIPTION
Found that pods are terminating too early, and need a higher default wait period