### PR TITLE
Fix import chain

### DIFF
--- a/packages/datadog/package.json
+++ b/packages/datadog/package.json
@@ -19,7 +19,7 @@
     "lib"
   ],
   "peerDependencies": {
-    "steveo": "^6.7.0"
+    "steveo": "*"
   },
   "peerDependenciesMeta": {
     "steveo": {
@@ -34,7 +34,7 @@
     "nyc": "^15.1.0",
     "prettier": "2.8.8",
     "source-map-support": "0.5.21",
-    "steveo": "^6.7.0",
+    "steveo": "*",
     "ts-node": "10.9.2",
     "typescript": "^5.3.3"
   },

--- a/packages/datadog/package.json
+++ b/packages/datadog/package.json
@@ -18,14 +18,6 @@
   "files": [
     "lib"
   ],
-  "peerDependencies": {
-    "steveo": "*"
-  },
-  "peerDependenciesMeta": {
-    "steveo": {
-      "optional": false
-    }
-  },
   "devDependencies": {
     "@ordermentum/eslint-config-ordermentum": "^2.3.3",
     "@types/chai": "^4.3.11",

--- a/packages/datadog/src/global.d.ts
+++ b/packages/datadog/src/global.d.ts
@@ -1,6 +1,0 @@
-// This file is required to resolve build issues in the @smithie DO NOT REMOVE THIS FILE, yet.
-export {};
-
-declare global {
-  interface ReadableStream {}
-}

--- a/packages/newrelic/package.json
+++ b/packages/newrelic/package.json
@@ -19,13 +19,7 @@
     "lib"
   ],
   "peerDependencies": {
-    "newrelic": "^9.8.0",
-    "steveo": "*"
-  },
-  "peerDependenciesMeta": {
-    "steveo": {
-      "optional": false
-    }
+    "newrelic": "^9.8.0"
   },
   "devDependencies": {
     "@types/newrelic": "^9.4.0",
@@ -54,6 +48,7 @@
     "prettier": "2.8.8",
     "sinon": "15.2.0",
     "source-map-support": "0.5.21",
+    "steveo": "*",
     "ts-node": "10.9.2",
     "typescript": "5.1.3"
   }

--- a/packages/newrelic/package.json
+++ b/packages/newrelic/package.json
@@ -19,10 +19,13 @@
     "lib"
   ],
   "peerDependencies": {
-    "newrelic": "^9.8.0"
+    "newrelic": "^9.8.0",
+    "steveo": "*"
   },
-  "dependencies": {
-    "steveo": "^6.3.0"
+  "peerDependenciesMeta": {
+    "steveo": {
+      "optional": false
+    }
   },
   "devDependencies": {
     "@types/newrelic": "^9.4.0",

--- a/packages/newrelic/src/global.d.ts
+++ b/packages/newrelic/src/global.d.ts
@@ -1,6 +1,0 @@
-// This file is required to resolve build issues in the @smithie DO NOT REMOVE THIS FILE, yet.
-export {};
-
-declare global {
-  interface ReadableStream {}
-}

--- a/packages/scheduler-prisma/src/global.d.ts
+++ b/packages/scheduler-prisma/src/global.d.ts
@@ -1,6 +1,0 @@
-// This file is required to resolve build issues in the @smithie DO NOT REMOVE THIS FILE, yet.
-export {};
-
-declare global {
-  interface ReadableStream {}
-}

--- a/packages/scheduler-sequelize/src/global.d.ts
+++ b/packages/scheduler-sequelize/src/global.d.ts
@@ -1,6 +1,0 @@
-// This file is required to resolve build issues in the @smithie DO NOT REMOVE THIS FILE, yet.
-export {};
-
-declare global {
-  interface ReadableStream {}
-}

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -18,9 +18,16 @@
   "files": [
     "lib"
   ],
+  "peerDependencies": {
+    "steveo": "*"
+  },
+  "peerDependenciesMeta": {
+    "steveo": {
+      "optional": false
+    }
+  },
   "dependencies": {
-    "@sentry/node": "^7.56.0",
-    "steveo": "^6.3.0"
+    "@sentry/node": "^7.56.0"
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "1.0.2",

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -18,14 +18,6 @@
   "files": [
     "lib"
   ],
-  "peerDependencies": {
-    "steveo": "*"
-  },
-  "peerDependenciesMeta": {
-    "steveo": {
-      "optional": false
-    }
-  },
   "dependencies": {
     "@sentry/node": "^7.56.0"
   },
@@ -54,6 +46,7 @@
     "prettier": "2.8.8",
     "sinon": "15.2.0",
     "source-map-support": "0.5.21",
+    "steveo": "*",
     "ts-node": "10.9.2",
     "typescript": "5.1.3"
   }

--- a/packages/sentry/src/global.d.ts
+++ b/packages/sentry/src/global.d.ts
@@ -1,6 +1,0 @@
-// This file is required to resolve build issues in the @smithie DO NOT REMOVE THIS FILE, yet.
-export {};
-
-declare global {
-  interface ReadableStream {}
-}

--- a/packages/statsd/package.json
+++ b/packages/statsd/package.json
@@ -19,8 +19,7 @@
     "lib"
   ],
   "dependencies": {
-    "hot-shots": "^10.0.0",
-    "steveo": "*"
+    "hot-shots": "^10.0.0"
   },
   "devDependencies": {
     "@types/newrelic": "^9.4.0",
@@ -48,6 +47,7 @@
     "prettier": "2.8.8",
     "sinon": "15.2.0",
     "source-map-support": "0.5.21",
+    "steveo": "*",
     "ts-node": "10.9.2",
     "typescript": "5.1.3"
   }

--- a/packages/statsd/package.json
+++ b/packages/statsd/package.json
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "hot-shots": "^10.0.0",
-    "steveo": "^6.3.0"
+    "steveo": "*"
   },
   "devDependencies": {
     "@types/newrelic": "^9.4.0",

--- a/packages/statsd/src/global.d.ts
+++ b/packages/statsd/src/global.d.ts
@@ -1,6 +1,0 @@
-// This file is required to resolve build issues in the @smithie DO NOT REMOVE THIS FILE, yet.
-export {};
-
-declare global {
-  interface ReadableStream {}
-}

--- a/packages/steveo/src/common.ts
+++ b/packages/steveo/src/common.ts
@@ -8,6 +8,11 @@ import {
   ProducerTopicConfig,
 } from 'node-rdkafka';
 
+// https://github.com/aws/aws-sdk-js-v3/issues/3063
+// 🤌🏾🤌🏾🤌🏾
+declare global {
+  interface ReadableStream {}
+}
 /**
  * FIXME: for callbacks that don't take an argument, need to specify
  * T = void to make the parameter optional

--- a/packages/steveo/src/producers/sqs.ts
+++ b/packages/steveo/src/producers/sqs.ts
@@ -1,5 +1,5 @@
 import nullLogger from 'null-logger';
-// import { SQS } from 'aws-sdk';
+
 import {
   CreateQueueCommandInput,
   CreateQueueCommandOutput,
@@ -25,10 +25,6 @@ import {
 
 import { createMessageMetadata } from '../lib/context';
 import { BaseProducer } from './base';
-
-declare global {
-  interface ReadableStream {}
-}
 
 class SqsProducer extends BaseProducer implements IProducer {
   config: SQSConfiguration;

--- a/packages/steveo/src/producers/sqs.ts
+++ b/packages/steveo/src/producers/sqs.ts
@@ -26,6 +26,10 @@ import {
 import { createMessageMetadata } from '../lib/context';
 import { BaseProducer } from './base';
 
+declare global {
+  interface ReadableStream {}
+}
+
 class SqsProducer extends BaseProducer implements IProducer {
   config: SQSConfiguration;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "lib": [
-      "ES2022"
+      "ES2022",
     ],
     "module": "commonjs",
     "moduleResolution": "node",


### PR DESCRIPTION
* Move steveo to a dev dependency so that turbo builds it first
* use the `*` so that turbo gets the right version of steveo
* put the ReadableStream declaration into the common file because AWS have some weird type issues