### PR TITLE
[PLATFORMS-1544] Implement dd-trace in DD middleware

### DIFF
--- a/.changeset/tricky-squids-bow.md
+++ b/.changeset/tricky-squids-bow.md
@@ -1,0 +1,9 @@
+---
+"@steveojs/datadog": minor
+---
+
+Updates DatadogMiddleware propagate the DD traces down the message life cycle.
+
+1. During the message publishing the extracts the trace_id and parent_id from the current context and injects it to the message _meta attributes, under the datadog key.
+
+2. During the message processing, if the message _meta attributes contains a datadog key, then its content is extracted and associated with the current context as a parent.

--- a/packages/datadog/src/index.ts
+++ b/packages/datadog/src/index.ts
@@ -1,9 +1,10 @@
 /* eslint-disable no-underscore-dangle */
-import tracer from 'dd-trace';
+import tracer, { SpanOptions } from 'dd-trace';
 import { Middleware } from 'steveo';
+import { MiddlewareContext } from 'steveo/lib/common';
 
 export class DataDogMiddleware implements Middleware {
-  publish(context, next) {
+  public publish(context, next) {
     return tracer.trace(
       'steveo.publish',
       {
@@ -12,21 +13,42 @@ export class DataDogMiddleware implements Middleware {
           ...context.payload,
         },
       },
-      () => next()
+      (span: tracer.Span | undefined) => {
+        if (span) {
+          const datadogContextData: Record<string, any> = {};
+          tracer.inject(span, 'text_map', datadogContextData);
+          const meta = this.getMetaFromContext(context);
+          meta.datadog = datadogContextData;
+          context.payload._meta = meta;
+        }
+        next(context);
+      }
     );
   }
 
-  async consume(context, next) {
-    return tracer.trace(
-      'steveo.consume',
-      {
-        resource: context.topic,
-        tags: {
-          ...context.payload,
-        },
+  public async consume(context, next) {
+    const tracerOptions: tracer.TraceOptions & SpanOptions = {
+      resource: context.topic,
+      tags: {
+        ...context.payload,
       },
-      () => next()
+    };
+
+    const meta: Record<string, any> = this.getMetaFromContext(context);
+    const datadogContext = meta.datadog ?? {};
+    const spanContext: tracer.SpanContext | null = tracer.extract(
+      'text_map',
+      datadogContext
     );
+    if (spanContext) {
+      tracerOptions.childOf = spanContext;
+    }
+
+    return tracer.trace('steveo.consume', tracerOptions, () => next(context));
+  }
+
+  private getMetaFromContext(context: MiddlewareContext): Record<string, any> {
+    return context.payload._meta ?? {};
   }
 }
 

--- a/packages/datadog/test/index_test.ts
+++ b/packages/datadog/test/index_test.ts
@@ -1,20 +1,14 @@
 import { expect } from 'chai';
 import { Steveo } from 'steveo';
-import DataDogMiddleware from '../src';
 
 import sinon from 'sinon';
-import tracer from 'dd-trace';
-import {MiddlewareCallback, MiddlewareContext} from 'steveo/lib/common';
+import tracer, { SpanOptions } from 'dd-trace';
+import { MiddlewareCallback, MiddlewareContext } from 'steveo/lib/common';
+import DataDogMiddleware from '../src';
 
 describe('DataDogMiddleware', () => {
-  let middleware: DataDogMiddleware;
-
-  beforeEach(() => {
-    middleware = new DataDogMiddleware();
-  });
-
   afterEach(() => {
-    sinon.restore(); // Restore original functionality after each test
+    sinon.restore();
   });
 
   it('add to steveo', () => {
@@ -29,22 +23,29 @@ describe('DataDogMiddleware', () => {
 
   describe('publish', () => {
     it('should call tracer.trace and inject datadogContextData into context.payload._meta if span exists', () => {
-
-      const injectStub = sinon.stub(tracer, "inject");
-      injectStub.calledWith(sinon.match.typeOf('SpanContext'), 'text_map', {})
+      const middleware: DataDogMiddleware = new DataDogMiddleware();
+      const injectStub = sinon.stub(tracer, 'inject');
+      injectStub.calledWith(
+        sinon.match.typeOf('SpanContext'),
+        middleware.DATADOG_CONTEXT_FORMAT,
+        {}
+      );
 
       const fakeSpanData = {
         spanId: '12345678910',
         traceId: '10987654321',
-      }
-      sinon.stub(DataDogMiddleware.prototype, <any>'getDatadogContextData')
+      };
+      sinon
+        .stub(DataDogMiddleware.prototype, <any>'getDatadogContextData')
         .returns(fakeSpanData);
 
-      const expectedDatadogContext = {
-        datadog: fakeSpanData
-      }
-      const next: MiddlewareCallback = (context: MiddlewareContext): Promise<void> => {
-        expect(expectedDatadogContext).to.be.deep.equal(context.payload._meta)
+      const expectedDatadogContext: Record<string, any> = {
+        datadog: fakeSpanData,
+      };
+      const next: MiddlewareCallback = (
+        context: MiddlewareContext
+      ): Promise<void> => {
+        expect(expectedDatadogContext).to.be.deep.equal(context.payload._meta);
         return Promise.resolve();
       };
 
@@ -54,17 +55,102 @@ describe('DataDogMiddleware', () => {
       };
       middleware.publish(context, next);
     });
-  });
-});
 
-describe('DataDogMiddleware', () => {
-  it('add to steveo', () => {
-    const middleware = new DataDogMiddleware();
-    const steveo = new Steveo({
-      engine: 'dummy',
-      middleware: [middleware],
+    it('should make sure tracer.tracer calls the next function with context as argument', async () => {
+      const context: MiddlewareContext = {
+        topic: 'test-topic',
+        payload: {
+          _meta: {},
+        },
+      };
+
+      const middleware: DataDogMiddleware = new DataDogMiddleware();
+      middleware.publish(
+        context,
+        (middlewareContext: MiddlewareContext): Promise<void> => {
+          expect(middlewareContext).to.be.deep.equal(context);
+          return Promise.resolve();
+        }
+      );
+    });
+  });
+
+  describe('consume', () => {
+    it('should call tracer.trace without childOf when spanContext does not exist', async () => {
+      const context: MiddlewareContext = {
+        topic: 'test-topic',
+        payload: {
+          _meta: {},
+        },
+      };
+      const expectedTracerOptions: tracer.TraceOptions & SpanOptions = {
+        resource: context.topic,
+        tags: {
+          ...context.payload,
+        },
+      };
+      const middleware: DataDogMiddleware = new DataDogMiddleware();
+      const tracerStub = sinon.stub(tracer);
+      tracerStub.extract.callsFake((format: string, carrier: any) => {
+        expect(middleware.DATADOG_CONTEXT_FORMAT).to.be.equal(format);
+        expect({}).to.be.deep.equal(carrier);
+        return null;
+      });
+      tracerStub.trace.callsFake(
+        (name: string, options: tracer.TraceOptions, _) => {
+          expect(name).to.be.equal('steveo.consume');
+          expect(options).to.be.deep.equal(expectedTracerOptions);
+        }
+      );
+
+      await middleware.consume(
+        context,
+        (_: MiddlewareContext): Promise<void> => Promise.resolve()
+      );
     });
 
-    expect(steveo.middleware.length).to.equal(1);
+    it('should call tracer.trace with childOf when spanContext exists', async () => {
+      const expectedContext: MiddlewareContext = {
+        payload: {
+          _meta: {
+            datadog: {
+              traceId: 'abc123',
+              spanId: '321abc',
+            },
+          },
+        },
+        topic: 'test-topic',
+      };
+
+      const tracerStub = sinon.stub(tracer, 'trace');
+      tracerStub.callsFake((name: string, options: tracer.TraceOptions, _) => {
+        expect(name).to.be.equal('steveo.consume');
+        expect(options).to.have.property('childOf');
+      });
+
+      const middleware: DataDogMiddleware = new DataDogMiddleware();
+      await middleware.consume(
+        expectedContext,
+        (_: MiddlewareContext): Promise<void> => Promise.resolve()
+      );
+    });
+
+    it('should make sure tracer.tracer calls the next function with context as argument', async () => {
+      const context: MiddlewareContext = {
+        topic: 'test-topic',
+        payload: {
+          _meta: {},
+        },
+      };
+
+      const middleware: DataDogMiddleware = new DataDogMiddleware();
+      await middleware.consume(
+        context,
+        (middlewareContext: MiddlewareContext): Promise<void> => {
+          expect(middlewareContext).to.be.deep.equal(context);
+          return Promise.resolve();
+        }
+      );
+    });
   });
 });

--- a/packages/datadog/test/index_test.ts
+++ b/packages/datadog/test/index_test.ts
@@ -2,6 +2,61 @@ import { expect } from 'chai';
 import { Steveo } from 'steveo';
 import DataDogMiddleware from '../src';
 
+import sinon from 'sinon';
+import tracer from 'dd-trace';
+import {MiddlewareCallback, MiddlewareContext} from 'steveo/lib/common';
+
+describe('DataDogMiddleware', () => {
+  let middleware: DataDogMiddleware;
+
+  beforeEach(() => {
+    middleware = new DataDogMiddleware();
+  });
+
+  afterEach(() => {
+    sinon.restore(); // Restore original functionality after each test
+  });
+
+  it('add to steveo', () => {
+    const middleware = new DataDogMiddleware();
+    const steveo = new Steveo({
+      engine: 'dummy',
+      middleware: [middleware],
+    });
+
+    expect(steveo.middleware.length).to.equal(1);
+  });
+
+  describe('publish', () => {
+    it('should call tracer.trace and inject datadogContextData into context.payload._meta if span exists', () => {
+
+      const injectStub = sinon.stub(tracer, "inject");
+      injectStub.calledWith(sinon.match.typeOf('SpanContext'), 'text_map', {})
+
+      const fakeSpanData = {
+        spanId: '12345678910',
+        traceId: '10987654321',
+      }
+      sinon.stub(DataDogMiddleware.prototype, <any>'getDatadogContextData')
+        .returns(fakeSpanData);
+
+      const expectedDatadogContext = {
+        datadog: fakeSpanData
+      }
+      const next: MiddlewareCallback = (context: MiddlewareContext): Promise<void> => {
+        expect(expectedDatadogContext).to.be.deep.equal(context.payload._meta)
+        return Promise.resolve();
+      };
+
+      const context: MiddlewareContext = {
+        payload: { key: 'value' },
+        topic: 'test-topic',
+      };
+      middleware.publish(context, next);
+    });
+  });
+});
+
 describe('DataDogMiddleware', () => {
   it('add to steveo', () => {
     const middleware = new DataDogMiddleware();

--- a/packages/datadog/tsconfig.json
+++ b/packages/datadog/tsconfig.json
@@ -22,7 +22,8 @@
     "esModuleInterop": true
   },
   "include": [
-    "src"
+    "src",
+    "test"
   ],
   "exclude": [
     "lib",


### PR DESCRIPTION
#### Description

Updates DatadogMiddleware propagate the DD traces down the message life cycle. [PLATFORM-1544](https://ordermentum.atlassian.net/browse/PLATFORM-1544)

1. During the message publishing the extracts the `trace_id` and `parent_id` from the current context and injects it to the message `_meta` attributes, under the `datadog` key.

2. During the message processing, if the message `_meta` attributes contains a datadog key, then its content is extracted and associated with the current context as a parent.

----
#### Changes
_List the main changes in this PR._

----

#### Testing Instructions
_Outline the steps to test or reproduce the PR._

----

#### Screenshots
_(if appropriate, they help the reviewer visualise the changes)_

----



[PLATFORM-1544]: https://ordermentum.atlassian.net/browse/PLATFORM-1544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ