### PR TITLE
Rename storage-postgres package and fix changeset

### DIFF
--- a/.changeset/rotten-chefs-sit.md
+++ b/.changeset/rotten-chefs-sit.md
@@ -1,5 +1,5 @@
 ---
-"steveo-store-postgres": patch
+"@steveojs/storage-postgres": patch
 ---
 
 Added postgres, prisma storage implementation of the Steveo storage abstractions

--- a/apps/workflows-example/package.json
+++ b/apps/workflows-example/package.json
@@ -27,7 +27,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "steveo": "*",
-    "@steveojs/store-postgres": "*",
+    "@steveojs/storage-postgres": "*",
     "aws-sdk": "^2.77.0",
     "bluebird": "^3.5.0",
     "bunyan": "^1.8.15",

--- a/apps/workflows-example/src/config.ts
+++ b/apps/workflows-example/src/config.ts
@@ -1,6 +1,6 @@
 import { load } from 'ts-dotenv';
 import Steveo, { SQSConfiguration } from 'steveo';
-import { postgresFactory, PostgresStorageConfig } from '@steveojs/store-postgres';
+import { postgresFactory, PostgresStorageConfig } from '@steveojs/storage-postgres';
 import bunyan from 'bunyan';
 
 export const logger = bunyan.createLogger({ name: 'workflow-test' });

--- a/packages/storage-postgres/package.json
+++ b/packages/storage-postgres/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@steveojs/store-postgres",
+  "name": "@steveojs/storage-postgres",
   "version": "6.7.0",
   "description": "Postgres persistence implementation for Steveo",
   "main": "lib/index.js",


### PR DESCRIPTION
#### Description

This PR fixes the broken release step due to mismatch in package name.

<img width="1350" alt="Screenshot 2024-09-26 at 14 42 50" src="https://github.com/user-attachments/assets/42ccc02d-3d62-48e4-81be-47a5a87597a9">


What changes:
- Rename `@steveojs/store-postgres` to `@steveojs/storerage-postgres` to match package folder name
- Update Change the to fix package name

----
#### Changes
_List the main changes in this PR._

----

#### Testing Instructions
_Outline the steps to test or reproduce the PR._

----

#### Screenshots
_(if appropriate, they help the reviewer visualise the changes)_

----

