### PR TITLE
[BUGFIX] Remove test folder from tsconfig include list

### DIFF
--- a/.changeset/fresh-tips-walk.md
+++ b/.changeset/fresh-tips-walk.md
@@ -1,0 +1,8 @@
+---
+"@steveojs/datadog": patch
+---
+
+Fix datadog lib folder structure, introduced by latest minor upgrade.
+In the 7.1.0 version, the tests folder was added to the includes list, in the
+tsconfig.json which caused the compile `lib` folder to contains new src and test
+folders instead of containing only the index.js entrypoint file.

--- a/packages/datadog/tsconfig.json
+++ b/packages/datadog/tsconfig.json
@@ -22,8 +22,7 @@
     "esModuleInterop": true
   },
   "include": [
-    "src",
-    "test"
+    "src"
   ],
   "exclude": [
     "lib",


### PR DESCRIPTION
#### Description

Fix datadog lib folder structure, introduced by latest minor upgrade.
In the 7.1.0 version, the tests folder was added to the includes list, in the `tsconfig.json` which caused the compile `lib` folder to contains new `src` and `test` folders instead of containing only the `index.js` entrypoint file.

Wrong structure:
<img width="252" alt="Screenshot 2024-09-26 at 19 01 23" src="https://github.com/user-attachments/assets/f4c2d8f5-ae66-4a94-b83f-26c47afcfd44">

Correct Structure:
<img width="242" alt="Screenshot 2024-09-26 at 19 03 11" src="https://github.com/user-attachments/assets/6ead8a96-319f-4ea3-b29e-5813680dbb30">

----
#### Changes
_List the main changes in this PR._

----

#### Testing Instructions
_Outline the steps to test or reproduce the PR._

----

#### Screenshots
_(if appropriate, they help the reviewer visualise the changes)_

----

