### PR TITLE
[BUGFIX] AWS SQS connection issues with credentials

### DIFF
--- a/.changeset/tough-dryers-greet.md
+++ b/.changeset/tough-dryers-greet.md
@@ -1,0 +1,11 @@
+---
+"steveo": patch
+---
+
+Fix configuration bug after AWS SQS upgrade.
+The issue occurred due to inconsistencies in local and non-local environments,
+because locally the AWS credentials env variables are required an env vars while
+in non-local we use the instance role, therefore the credentials are not required.
+
+The fix consists of a new attribute credentials in the config, set during local
+development only, which wrapper the AWS credentials.

--- a/packages/steveo/src/common.ts
+++ b/packages/steveo/src/common.ts
@@ -83,8 +83,10 @@ export interface SQSConfiguration extends Configuration {
   apiVersion: string;
   messageRetentionPeriod: string;
   receiveMessageWaitTimeSeconds: string;
-  accessKeyId?: string;
-  secretAccessKey?: string;
+  credentials?: {
+    accessKeyId: string;
+    secretAccessKey: string;
+  };
   maxNumberOfMessages: number;
   visibilityTimeout: number;
   waitTimeSeconds: number;

--- a/packages/steveo/src/config.ts
+++ b/packages/steveo/src/config.ts
@@ -58,8 +58,7 @@ export const getConfig = (config: Configuration) => {
     parameters.messageRetentionPeriod = sqsConfig.messageRetentionPeriod;
     parameters.receiveMessageWaitTimeSeconds =
       sqsConfig.receiveMessageWaitTimeSeconds;
-    parameters.accessKeyId = sqsConfig.accessKeyId;
-    parameters.secretAccessKey = sqsConfig.secretAccessKey;
+    parameters.credentials = sqsConfig.credentials;
     parameters.maxNumberOfMessages = sqsConfig.maxNumberOfMessages;
     parameters.visibilityTimeout = sqsConfig.visibilityTimeout;
     parameters.waitTimeSeconds = sqsConfig.waitTimeSeconds;

--- a/packages/steveo/src/config/sqs.ts
+++ b/packages/steveo/src/config/sqs.ts
@@ -1,20 +1,18 @@
 import { SQS, SQSClientConfig } from '@aws-sdk/client-sqs';
-import { NodeHttpHandler } from '@smithy/node-http-handler';
 import { Configuration, SQSConfiguration } from '../common';
 
 export const getSqsInstance = (config: Configuration): SQS => {
   const sqsConfig: SQSConfiguration = config as SQSConfiguration;
   const conf: SQSClientConfig = {
     region: sqsConfig.region,
-    credentials: {
-      accessKeyId: sqsConfig.accessKeyId ?? '',
-      secretAccessKey: sqsConfig.secretAccessKey ?? '',
-    },
-    endpoint: sqsConfig.endpoint,
   };
 
-  if (sqsConfig.httpOptions) {
-    conf.requestHandler = sqsConfig.httpOptions as NodeHttpHandler;
+  if (sqsConfig.endpoint !== undefined) {
+    conf.endpoint = sqsConfig.endpoint;
+  }
+
+  if (sqsConfig.credentials !== undefined) {
+    conf.credentials = sqsConfig.credentials;
   }
 
   return new SQS(conf);

--- a/packages/steveo/src/consumers/base.ts
+++ b/packages/steveo/src/consumers/base.ts
@@ -79,7 +79,9 @@ class BaseRunner {
   async reconnect() {}
 
   async stop() {
-    this.logger.debug(`stopping consumer ${this.name}`);
+    this.logger.debug(
+      `${this.config.engine.toUpperCase()}: stopping consumer ${this.name}`
+    );
     this.manager.state = 'terminating';
   }
 
@@ -87,7 +89,9 @@ class BaseRunner {
     if (!this.registry) return false;
 
     const topics = this.registry.getTopics();
-    this.logger.debug(`creating queues: ${topics}`);
+    this.logger.debug(
+      `${this.config.engine.toUpperCase()}: creating queues: ${topics}`
+    );
 
     if (!topics || topics.length === 0) {
       this.logger.debug('no topics found');
@@ -98,7 +102,9 @@ class BaseRunner {
       topics,
       (topic: string) =>
         this.createQueue(topic).catch(er => {
-          this.logger.error(`error creating queue for topic: ${er.toString()}`);
+          this.logger.error(
+            `${this.config.engine.toUpperCase()}: error creating queue for topic: ${er.toString()}`
+          );
         }),
       { concurrency: 10 }
     );

--- a/packages/steveo/src/producers/kafka.ts
+++ b/packages/steveo/src/producers/kafka.ts
@@ -42,23 +42,32 @@ class KafkaProducer
     }
     return new Promise<HighLevelProducer>((resolve, reject) => {
       const timeoutId = setTimeout(() => {
-        this.logger.error('Connection timed out');
+        this.logger.error(
+          `${this.config.engine.toUpperCase()}: Connection timed out`
+        );
         reject();
       }, (this.config as KafkaConfiguration).connectionTimeout!);
       this.producer.connect({}, err => {
         if (err) {
           clearTimeout(timeoutId);
-          this.logger.error('Error initializing producer', err);
+          this.logger.error(
+            `${this.config.engine.toUpperCase()}: Error initializing producer`,
+            err
+          );
           reject(err);
         }
       });
       this.producer.on('ready', () => {
         clearTimeout(timeoutId);
-        this.logger.debug('producer ready');
+        this.logger.debug(
+          `${this.config.engine.toUpperCase()}: producer ready`
+        );
         resolve(this.producer);
       });
       this.producer.on('disconnected', () => {
-        this.logger.debug('Producer disconnected');
+        this.logger.debug(
+          `${this.config.engine.toUpperCase()}: Producer disconnected`
+        );
       });
     });
   }
@@ -87,7 +96,7 @@ class KafkaProducer
       this.producer.produce(topic, null, data, key, Date.now(), err => {
         if (err) {
           this.logger.error(
-            'Error while sending payload:',
+            `${this.config.engine.toUpperCase()} Error while sending payload:`,
             JSON.stringify(data, null, 2),
             'topic :',
             topic,
@@ -122,7 +131,11 @@ class KafkaProducer
         this.registry.emit('producer_success', topic, c.payload);
       });
     } catch (ex) {
-      this.logger.error('Error while sending Redis payload', topic, ex);
+      this.logger.error(
+        `${this.config.engine.toUpperCase()}: Error while sending payload`,
+        topic,
+        ex
+      );
       this.registry.emit('producer_failure', topic, ex, payload);
       throw ex;
     }
@@ -132,7 +145,10 @@ class KafkaProducer
     if (this.producer.isConnected()) {
       this.producer.disconnect(err => {
         if (err) {
-          this.logger.error('Error while disconnecting producer', err);
+          this.logger.error(
+            `${this.config.engine.toUpperCase()}: Error while disconnecting producer`,
+            err
+          );
         }
       });
     }

--- a/packages/steveo/src/producers/sqs.ts
+++ b/packages/steveo/src/producers/sqs.ts
@@ -107,7 +107,10 @@ class SqsProducer extends BaseProducer implements IProducer {
       };
     }
 
-    this.logger.debug(`Creating queue`, util.inspect(params));
+    this.logger.debug(
+      `${this.config.engine.toUpperCase()}: Creating queue`,
+      util.inspect(params)
+    );
 
     const res: CreateQueueCommandOutput = await this.producer
       .createQueue(params)
@@ -154,19 +157,21 @@ class SqsProducer extends BaseProducer implements IProducer {
       };
 
       this.logger.debug(
-        `Creating DLQ for orginal queue ${queueName}`,
+        `${this.config.engine.toUpperCase()}: Creating DLQ for orginal queue ${queueName}`,
         util.inspect(params)
       );
 
       const res: CreateQueueCommandOutput = await this.producer
         .createQueue(params)
         .catch(err => {
-          throw new Error(`Failed to call SQS createQueue: ${err}`);
+          throw new Error(
+            `${this.config.engine.toUpperCase()}: Failed to call SQS createQueue: ${err}`
+          );
         });
 
       if (!res.QueueUrl) {
         throw new Error(
-          'SQS createQueue response does not contain a queue name'
+          `${this.config.engine.toUpperCase()}: createQueue response does not contain a queue name`
         );
       }
 
@@ -183,13 +188,17 @@ class SqsProducer extends BaseProducer implements IProducer {
       await this.producer
         .getQueueAttributes(getQueueAttributesParams)
         .catch(err => {
-          throw new Error(`Failed to call SQS getQueueAttributes: ${err}`);
+          throw new Error(
+            `${this.config.engine.toUpperCase()}: Failed to call SQS getQueueAttributes: ${err}`
+          );
         });
 
     const dlQueueArn: string | undefined =
       attributesResult.Attributes?.QueueArn;
     if (!dlQueueArn) {
-      throw new Error('Failed to retrieve the DLQ ARN');
+      throw new Error(
+        `${this.config.engine.toUpperCase()}: Failed to retrieve the DLQ ARN`
+      );
     }
 
     return {

--- a/packages/steveo/test/integration/sqs_test.ts
+++ b/packages/steveo/test/integration/sqs_test.ts
@@ -55,8 +55,10 @@ describe('SQS Integration Test', () => {
       messageRetentionPeriod: '604800',
       engine: 'sqs' as const,
       queuePrefix: `steveo`,
-      accessKeyId: 'test',
-      secretAccessKey: 'key',
+      credentials: {
+        accessKeyId: 'test',
+        secretAccessKey: 'key',
+      },
       shuffleQueue: false,
       endpoint: 'http://127.0.0.1:4566',
       maxNumberOfMessages: 1,

--- a/packages/steveo/test/producer/sqs_test.ts
+++ b/packages/steveo/test/producer/sqs_test.ts
@@ -20,6 +20,10 @@ describe('SQS Producer', () => {
       // @ts-ignore
       {
         engine: 'sqs',
+        credentials: {
+          accessKeyId: 'test',
+          secretAccessKey: 'key'
+        }
       },
       registry
     );


### PR DESCRIPTION
#### Description

The issue occurred due to inconsistencies in local and non-local environments, because locally the AWS credentials env variables are required while in non-local we use the instance role, therefore the credentials are not required.

This PR introduces a new configuration attributes in the SQS config called `credentials`, which is a wrapper around the optional `accessKeyId` and `secretAccessKey`.

The credentials attribute is also optional but the `accessKeyId` and `secretAccessKey` are not mandatory.

**PS: Do not worry about the changes on the consumers and producers.**  Those change only prefixing the engine name to the logs message to improve logs search. Eventually they could be in the log context, but that's a bigger change for the future.


----
#### Changes
_List the main changes in this PR._

----

#### Testing Instructions
_Outline the steps to test or reproduce the PR._

----

#### Screenshots
_(if appropriate, they help the reviewer visualise the changes)_

----

