### PR TITLE
[BUGFIX] Kafka producer failing with DatadogMiddleware

### DIFF
--- a/.changeset/fuzzy-hats-begin.md
+++ b/.changeset/fuzzy-hats-begin.md
@@ -1,0 +1,15 @@
+---
+"steveo": patch
+---
+
+There is an issue (more like an easter egg) preventing Kafka message from being
+produced when DatadogMiddleware is activated.
+
+The issue happens basically because DatadogMiddleware expects payload to be a
+dictionary so it can inject the Datadog traces in the message. However, Kafka is
+sending the `Message.value` attribute, which is a string causing the following error.
+
+`Cannot create property '_meta' on string '*' `
+
+The fix consists of making sure both Kafka producers and Kafka consumers sends
+the message payload as a dictionary to any registered middleware.

--- a/.changeset/fuzzy-hats-begin.md
+++ b/.changeset/fuzzy-hats-begin.md
@@ -11,5 +11,6 @@ sending the `Message.value` attribute, which is a string causing the following e
 
 `Cannot create property '_meta' on string '*' `
 
-The fix consists of making sure both Kafka producers and Kafka consumers sends
-the message payload as a dictionary to any registered middleware.
+The fix consists of changing DatadogMiddleware::publish to not add the datadog
+context attribute to the message whenever `MiddlewareContext.payload` is of type
+string.

--- a/.changeset/khaki-mayflies-pump.md
+++ b/.changeset/khaki-mayflies-pump.md
@@ -1,0 +1,7 @@
+---
+"@steveojs/datadog": patch
+---
+
+Change DatadogMiddleware::publish to verify whether `MiddlewareContext.payload`
+is a string, and if so, do not attempt to add the datadog trace_id to the message
+context.

--- a/packages/datadog/test/index_test.ts
+++ b/packages/datadog/test/index_test.ts
@@ -22,6 +22,18 @@ describe('DataDogMiddleware', () => {
   });
 
   describe('publish', () => {
+    it('should ignore traces when MiddlewareContext.payload is a string', async () => {
+      const context: MiddlewareContext = {
+        topic: 'test-topic',
+        payload: 'payload is a string',
+      };
+
+      const middleware: DataDogMiddleware = new DataDogMiddleware();
+      middleware.publish(context, (internalContext: MiddlewareContext) => {
+        expect(context).to.be.deep.equal(internalContext);
+      })
+    });
+
     it('should call tracer.trace and inject datadogContextData into context.payload._meta if span exists', () => {
       const middleware: DataDogMiddleware = new DataDogMiddleware();
       const injectStub = sinon.stub(tracer, 'inject');

--- a/packages/steveo/test/consumer/kafka_test.ts
+++ b/packages/steveo/test/consumer/kafka_test.ts
@@ -81,7 +81,6 @@ describe('runner/kafka', () => {
         engine: 'kafka',
         securityProtocol: 'plaintext',
       },
-      // @ts-ignore
       registry: anotherRegistry,
       // @ts-ignore
       pool: build(anotherRegistry),
@@ -125,7 +124,6 @@ describe('runner/kafka', () => {
         engine: 'kafka',
         securityProtocol: 'plaintext',
       },
-      // @ts-ignore
       registry: anotherRegistry,
       // @ts-ignore
       pool: build(anotherRegistry),
@@ -180,7 +178,6 @@ describe('runner/kafka', () => {
         securityProtocol: 'plaintext',
         waitToCommit: true,
       },
-      // @ts-ignore
       registry: anotherRegistry,
       // @ts-ignore
       pool: build(anotherRegistry),
@@ -263,7 +260,6 @@ describe('runner/kafka', () => {
         securityProtocol: 'plaintext',
         waitToCommit: true,
       },
-      // @ts-ignore
       registry: anotherRegistry,
       // @ts-ignore
       pool: build(anotherRegistry),
@@ -316,7 +312,6 @@ describe('runner/kafka', () => {
         securityProtocol: 'plaintext',
         waitToCommit: true,
       },
-      // @ts-ignore
       registry: anotherRegistry,
       // @ts-ignore
       pool: build(anotherRegistry),
@@ -390,7 +385,6 @@ describe('runner/kafka', () => {
           },
         ]
       },
-      // @ts-ignore
       registry: anotherRegistry,
       // @ts-ignore
       pool: build(anotherRegistry),

--- a/packages/steveo/test/consumer/kafka_test.ts
+++ b/packages/steveo/test/consumer/kafka_test.ts
@@ -358,4 +358,60 @@ describe('runner/kafka', () => {
     const expectedContext = getContext(messagePayload);
     expect(context, 'expected context').to.deep.equals(expectedContext);
   });
+
+  it('should unpack message value before forward payload to middleware', async () => {
+    const subscribeStub = sinon.stub();
+    const anotherRegistry = {
+      getTask: () => ({
+        publish: () => {},
+        subscribe: subscribeStub,
+      }),
+      emit: sandbox.stub(),
+      events: {
+        emit: sandbox.stub(),
+      },
+    };
+    const messagePayload: Record<string, string> = {
+      my: 'payload'
+    };
+    let receivedContext: Record<string, string> = {};
+    const steveo = {
+      config: {
+        bootstrapServers: 'kafka:9200',
+        engine: 'kafka',
+        securityProtocol: 'plaintext',
+        waitToCommit: true,
+        middleware: [
+          {
+            publish: () => {},
+            consume: (context) => {
+              receivedContext = context.payload;
+            },
+          },
+        ]
+      },
+      // @ts-ignore
+      registry: anotherRegistry,
+      // @ts-ignore
+      pool: build(anotherRegistry),
+      manager: {
+        state: 'running',
+      },
+    };
+    // @ts-ignore
+    const anotherRunner = new Runner(steveo);
+
+    sandbox.stub(anotherRunner.consumer, 'commitMessage');
+
+    await anotherRunner.consumeCallback(null, [
+      {
+        value: JSON.stringify(messagePayload),
+        size: 1000,
+        offset: 0,
+        topic: 'a-topic',
+        partition: 1,
+      },
+    ]);
+    expect(messagePayload).to.be.deep.equal(receivedContext);
+  });
 });

--- a/packages/steveo/test/producer/kafka_test.ts
+++ b/packages/steveo/test/producer/kafka_test.ts
@@ -182,34 +182,4 @@ describe('Kafka Producer', () => {
     expect(disconnectStub.callCount).to.equal(0);
   });
 
-  it('should unpack message before calling middleware wrapper in message is a string', async () => {
-    const registry = new Registry();
-
-    const payload: Record<string, string> = {
-      my: 'payload'
-    };
-    const p = new Producer(
-      {
-        engine: 'kafka',
-        bootstrapServers: 'kafka:9200',
-        securityProtocol: 'plaintext',
-        tasksPath: '',
-        middleware: [
-          {
-            publish: (context: any, _) => {
-              expect(payload).to.deep.equal(context.payload);
-            },
-            consume: () => {}
-        }]
-      },
-      registry
-    );
-
-    registry.addTopic('test-topic');
-    const sendStub = sandbox.stub(p.producer, 'produce');
-    sendStub.callsArgWith(5);
-
-    p.send('test-topic', JSON.stringify(payload));
-  });
-
 });

--- a/packages/steveo/test/producer/kafka_test.ts
+++ b/packages/steveo/test/producer/kafka_test.ts
@@ -181,4 +181,35 @@ describe('Kafka Producer', () => {
     await p.stop();
     expect(disconnectStub.callCount).to.equal(0);
   });
+
+  it('should unpack message before calling middleware wrapper in message is a string', async () => {
+    const registry = new Registry();
+
+    const payload: Record<string, string> = {
+      my: 'payload'
+    };
+    const p = new Producer(
+      {
+        engine: 'kafka',
+        bootstrapServers: 'kafka:9200',
+        securityProtocol: 'plaintext',
+        tasksPath: '',
+        middleware: [
+          {
+            publish: (context: any, _) => {
+              expect(payload).to.deep.equal(context.payload);
+            },
+            consume: () => {}
+        }]
+      },
+      registry
+    );
+
+    registry.addTopic('test-topic');
+    const sendStub = sandbox.stub(p.producer, 'produce');
+    sendStub.callsArgWith(5);
+
+    p.send('test-topic', JSON.stringify(payload));
+  });
+
 });


### PR DESCRIPTION
#### Description

There is an issue (more like an easter egg) preventing Kafka message from being produced when `DatadogMiddleware` is activated.

The issue happens basically because `DatadogMiddleware` expectes payload to be a dictionary so it can inject the Datadog traces in the message. However, Kafka is sending a Message.value attribute, which is a string causing the following error.

```
Cannot create property '_meta' on string '*' 
```

This PR makes sure that both Kafka producers and Kafra consumers sends the payload to all middlewares as a dictionary, instead of a dictionary.

----
#### Changes
_List the main changes in this PR._

----

#### Testing Instructions
_Outline the steps to test or reproduce the PR._

----

#### Screenshots
_(if appropriate, they help the reviewer visualise the changes)_

----

