### PR TITLE
Fix datadog context receiving incorrect object

### DIFF
--- a/.changeset/breezy-chicken-notice.md
+++ b/.changeset/breezy-chicken-notice.md
@@ -1,0 +1,5 @@
+---
+"@steveojs/datadog": patch
+---
+
+Fix DatadogMiddleware::getDatadogContextData receiving incorrect argument

--- a/packages/datadog/src/index.ts
+++ b/packages/datadog/src/index.ts
@@ -15,7 +15,7 @@ export class DataDogMiddleware implements Middleware {
         const shouldConnectDatadogTrace = typeof context.payload !== 'string';
         if (span && shouldConnectDatadogTrace) {
           const messageMetadata = this.getMetaFromContext(context);
-          messageMetadata.datadog = this.getDatadogContextData(context);
+          messageMetadata.datadog = this.getDatadogContextData(span);
           context.payload._meta = messageMetadata;
         }
         next(context);


### PR DESCRIPTION
#### Description

Datadog middleware sends an incorrect object to the function that extracts Datadog context info from the current span.

This is causing the spans not to connect anymore.

----
#### Changes
_List the main changes in this PR._

----

#### Testing Instructions
_Outline the steps to test or reproduce the PR._

----

#### Screenshots
_(if appropriate, they help the reviewer visualise the changes)_

----

