### PR TITLE
Remove double logging of the same message

### DIFF
--- a/.changeset/moody-countries-end.md
+++ b/.changeset/moody-countries-end.md
@@ -1,0 +1,5 @@
+---
+"steveo": patch
+---
+
+Remove duplicate log line

--- a/packages/steveo/src/consumers/sqs.ts
+++ b/packages/steveo/src/consumers/sqs.ts
@@ -57,7 +57,7 @@ class SqsRunner extends BaseRunner implements IRunner {
         this.logger.info(message, `Message received for task: ${topic}`);
         const params = JSON.parse(message.Body as string);
         await this.wrap({ topic, payload: params }, async c => {
-          this.logger.info(message, `Message received for task: ${c.topic}`);
+          this.logger.debug(message, `Handling message for task: ${c.topic}`);
           let resource: Resource | null = null;
           const { _meta: _, ...data } = c.payload;
           const runnerContext = getContext(c.payload);


### PR DESCRIPTION
#### Description

We currently log _"Message received for task"_ twice per message, which may mislead people into believing they are receiving and/or handling more messages than they actually are.

<img width="867" alt="image" src="https://github.com/user-attachments/assets/435a7f08-2abf-4243-af1d-e1413fd0da59">


----
#### Changes

Changes the second log instance to a `debug` log with a different message.

----

#### Testing Instructions
_Outline the steps to test or reproduce the PR._

----

#### Screenshots
_(if appropriate, they help the reviewer visualise the changes)_

----

