### PR TITLE
add workflow deletion option on completion

### DIFF
--- a/packages/steveo/src/index.ts
+++ b/packages/steveo/src/index.ts
@@ -109,7 +109,10 @@ export class Steveo implements ISteveo {
    * @param topic
    * @returns
    */
-  flow(name: string, options: WorkflowOptions = { serviceId: 'DEFAULT' }) {
+  flow(
+    name: string,
+    options: WorkflowOptions = { serviceId: 'DEFAULT', deleteOnComplete: true }
+  ) {
     const queueFormatOptions: QueueFormatOptions = {
       queueName: options.queueName,
       upperCaseNames: this.config.upperCaseNames,

--- a/packages/steveo/src/runtime/workflow.ts
+++ b/packages/steveo/src/runtime/workflow.ts
@@ -138,7 +138,15 @@ export class Workflow {
     // mark the flow completed if there are no more steps
     const next = this.getNextStep(current);
     if (!next) {
-      await context.repos.workflow.updateWorkflowCompleted(workflowId);
+      // Clean up workflow on completion if configured to do so, otherwise
+      // just update to a completed state. Typically workflows are not deleted
+      // in development environments only.
+      if (this.options.deleteOnComplete) {
+        await context.repos.workflow.deleteWorkflow(workflowId);
+      } else {
+        await context.repos.workflow.updateWorkflowCompleted(workflowId);
+      }
+
       return;
     }
 

--- a/packages/steveo/src/types/workflow-repo.ts
+++ b/packages/steveo/src/types/workflow-repo.ts
@@ -27,6 +27,12 @@ export interface WorkflowStateRepository {
   updateWorkflowCompleted(workflowId: string): Promise<void>;
 
   /**
+   * Delete a workflow from storage
+   * This is generally done when a workflow completes
+   */
+  deleteWorkflow(workflowId: string): Promise<void>;
+
+  /**
    * Update the given workflow ID current step name
    */
   updateCurrentStep(workflowId: string, stepName: string): Promise<void>;

--- a/packages/steveo/src/types/workflow.ts
+++ b/packages/steveo/src/types/workflow.ts
@@ -13,7 +13,16 @@ export interface WorkflowPayload {
  */
 export interface WorkflowOptions extends TaskOptions {
   /**
-   *
+   * Debug ID for this service
+   * Will be used to detect cross service workflow message processing too.
    */
   serviceId: string;
+
+  /**
+   * If true the engine will delete the workflow from storage.
+   * This is used in production systems as workflow states are considered
+   * transient, whereas developers may disable this for development and
+   * diagnostics.
+   */
+  deleteOnComplete: boolean;
 }

--- a/packages/steveo/test/workflow/fixtures/repo_fixture.ts
+++ b/packages/steveo/test/workflow/fixtures/repo_fixture.ts
@@ -16,6 +16,7 @@ export class MemoryStateRepository implements WorkflowStateRepository {
     init: 0,
     load: 0,
     completed: 0,
+    delete: 0,
     pointerUpdate: 0,
     rollbacks: 0,
     errors: 0,
@@ -29,6 +30,7 @@ export class MemoryStateRepository implements WorkflowStateRepository {
       init: 0,
       load: 0,
       completed: 0,
+      delete: 0,
       pointerUpdate: 0,
       rollbacks: 0,
       errors: 0,
@@ -67,6 +69,13 @@ export class MemoryStateRepository implements WorkflowStateRepository {
 
     this.calls.completed += 1;
     this.completed = true;
+
+    return Promise.resolve();
+  }
+
+  deleteWorkflow(_workflowId: string): Promise<void> {
+    this.state = undefined;
+    this.calls.delete += 1;
 
     return Promise.resolve();
   }

--- a/packages/steveo/test/workflow/fixtures/workflow_fixture.ts
+++ b/packages/steveo/test/workflow/fixtures/workflow_fixture.ts
@@ -9,7 +9,12 @@ import { consoleLogger } from '../../../src/lib/logger';
 /**
  *
  */
-export function workflowFixture(sandbox: sinon.SinonSandbox) {
+export function workflowFixture(
+  sandbox: sinon.SinonSandbox,
+  options: { deleteOnComplete: boolean } = {
+    deleteOnComplete: true,
+  }
+) {
   const repository = new MemoryStateRepository();
   const repos: Repositories = {
     workflow: repository,
@@ -31,6 +36,7 @@ export function workflowFixture(sandbox: sinon.SinonSandbox) {
     producer: fromStub(producer),
     options: {
       serviceId: 'test-service',
+      deleteOnComplete: options.deleteOnComplete,
     },
     logger: consoleLogger,
   });

--- a/packages/steveo/test/workflow/workflow_test.ts
+++ b/packages/steveo/test/workflow/workflow_test.ts
@@ -120,7 +120,7 @@ describe('Workflow tests', () => {
   it('should delete workflow on completion if configured', async () => {
     // ARRANGE
     const { workflow, repository } = workflowFixture(sandbox, {
-      deleteOnComplete: false,
+      deleteOnComplete: true,
     });
     const step1 = fixtures.stepReturn('step-1', 'step1-result');
 

--- a/packages/storage-postgres/src/repo/workflow-postgres-repo.ts
+++ b/packages/storage-postgres/src/repo/workflow-postgres-repo.ts
@@ -74,6 +74,17 @@ export class WorkflowStateRepositoryPostgres
   /**
    *
    */
+  async deleteWorkflow(workflowId: string): Promise<void> {
+    await this.prisma.workflowState.delete({
+      where: {
+        workflowId,
+      },
+    });
+  }
+
+  /**
+   *
+   */
   async updateCurrentStep(workflowId: string, stepName: string): Promise<void> {
     const result = await this.prisma.workflowState.update({
       where: {


### PR DESCRIPTION
#### Description

Workflows should delete their state from the postgres db upon successful completion.

This PR adds a new option to the workflow (default 'true') to delete completed states. This has been made optional so developers can opt not to delete them during development for debug purposes.
