### PR TITLE
[DevX-143] Refactor publish methods across engines to support message routing options

### DIFF
--- a/.changeset/purple-starfishes-sell.md
+++ b/.changeset/purple-starfishes-sell.md
@@ -1,0 +1,5 @@
+---
+"steveo": major
+---
+
+Add FIFO queue parameters support

--- a/packages/steveo/src/common.ts
+++ b/packages/steveo/src/common.ts
@@ -155,6 +155,26 @@ export interface IRegistry {
   getTask(topic: string): RegistryElem | null;
 }
 
+/**
+ * @description Message options for the producer
+ */
+export interface IMessageRoutingOptions {
+  /**
+   * @description Based on the engine, the key works differently:
+   * Kafka - Determines which partition this message lands in.
+   *         See https://www.confluent.io/learn/kafka-message-key/
+   * SQS (FIFO queues only) - Groups messages with the same key.
+   *         See https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagegroupid-property.html
+   */
+  key?: string;
+  /**
+   * @description Only works for SQS FIFO Queues
+   * If a message with a particular message deduplication ID is sent successfully, any messages sent with the same message deduplication ID are accepted successfully but aren't delivered during the 5-minute deduplication interval.
+   * SQS FIFO engine uses content based deduplication by default if no message deduplication ID is provided.
+   */
+  deDuplicationId?: string;
+}
+
 export interface ITask<T = any, R = any> {
   config: Configuration;
   registry: IRegistry;
@@ -163,7 +183,7 @@ export interface ITask<T = any, R = any> {
   topic: string;
   options: TaskOptions;
   producer: any;
-  publish(payload: T | T[], context?: { key: string }): Promise<void>;
+  publish(payload: T | T[], options?: IMessageRoutingOptions): Promise<void>;
 }
 
 export interface IRunner<T = any, M = any> {
@@ -216,14 +236,12 @@ export interface IProducer<P = any> {
   getPayload<T = any>(
     msg: T,
     topic: string,
-    key?: string,
-    context?: { [key: string]: string }
+    options?: IMessageRoutingOptions
   ): any;
   send<T = any>(
     topic: string,
     payload: T,
-    key?: string,
-    context?: { [key: string]: string }
+    options?: IMessageRoutingOptions
   ): Promise<void>;
   // FIXME: Replace T = any with Record<string, any> or an explicit list of
   // types we will handle as first-class citizens,

--- a/packages/steveo/src/index.ts
+++ b/packages/steveo/src/index.ts
@@ -25,6 +25,7 @@ import {
   SQSConfiguration,
   DummyConfiguration,
   Middleware,
+  IMessageRoutingOptions,
 } from './common';
 import { Storage } from './types/storage';
 import { TaskOptions } from './types/task-options';
@@ -173,9 +174,13 @@ export class Steveo implements ISteveo {
    * Publish the given payload to the given topic
    * @param key
    */
-  async publish<T = any>(name: string, payload: T, key?: string) {
+  async publish<T = any>(
+    name: string,
+    payload: T,
+    options?: IMessageRoutingOptions
+  ) {
     const topic = this.registry.getTopic(name);
-    return this.producer.send<T>(topic, payload, key);
+    return this.producer.send<T>(topic, payload, options);
   }
 
   /**

--- a/packages/steveo/src/lib/logger.ts
+++ b/packages/steveo/src/lib/logger.ts
@@ -12,6 +12,7 @@ export interface Logger {
   info(format: LogEntry, ...params: unknown[]): void;
   debug(format: LogEntry, ...params: unknown[]): void;
   error(format: LogEntry, ...params: unknown[]): void;
+  warn(format: LogEntry, ...params: unknown[]): void;
 }
 
 /**
@@ -37,6 +38,7 @@ function loggerFactory<T>(baseEntry?: T): Logger {
     info: output,
     debug: output,
     error: output,
+    warn: output,
   };
 }
 

--- a/packages/steveo/src/producers/kafka.ts
+++ b/packages/steveo/src/producers/kafka.ts
@@ -128,6 +128,11 @@ class KafkaProducer
     options: IMessageRoutingOptions = {}
   ) {
     try {
+      if (options.deDuplicationId) {
+        this.logger.warn(
+          'Deduplication with ID [deDuplicationId] is not supported for Kafka tasks'
+        );
+      }
       await this.wrap({ topic, payload }, async c => {
         const data = this.getPayload(c.payload, topic, options);
         await this.publish(c.topic, data, options.key);

--- a/packages/steveo/src/runtime/task.ts
+++ b/packages/steveo/src/runtime/task.ts
@@ -7,6 +7,7 @@ import {
   Callback,
   IProducer,
   IRegistry,
+  IMessageRoutingOptions,
 } from '../common';
 import { TaskOptions } from '../types/task-options';
 
@@ -51,7 +52,7 @@ class Task<T = any, R = any> implements ITask<T, R> {
     this.options = options;
   }
 
-  async publish(payload: T | T[], context?: { key: string }) {
+  async publish(payload: T | T[], options?: IMessageRoutingOptions) {
     let params;
     if (!Array.isArray(payload)) {
       params = [payload];
@@ -64,7 +65,7 @@ class Task<T = any, R = any> implements ITask<T, R> {
       await Promise.all(
         params.map((data: T) => {
           this.registry.emit('task_send', this.topic, data);
-          return this.producer.send(this.topic, data, context?.key, context);
+          return this.producer.send(this.topic, data, options);
         })
       );
       this.registry.emit('task_success', this.topic, payload);

--- a/packages/steveo/src/runtime/workflow.ts
+++ b/packages/steveo/src/runtime/workflow.ts
@@ -2,7 +2,7 @@ import { v4 } from 'uuid';
 import assert from 'node:assert';
 import { bind, take } from '../lib/not-lodash';
 import { Step, StepUnknown } from '../types/workflow-step';
-import { IProducer, IRegistry } from '../common';
+import { IMessageRoutingOptions, IProducer, IRegistry } from '../common';
 import { WorkflowState } from '../types/workflow-state';
 import { Repositories, Storage } from '../types/storage';
 import { WorkflowOptions, WorkflowPayload } from '../types/workflow';
@@ -103,16 +103,14 @@ export class Workflow {
    */
   async publish<T extends WorkflowPayload>(
     payload: T | T[],
-    context?: {
-      key?: string;
-    }
+    options?: IMessageRoutingOptions
   ) {
     const step = this.steps[0];
 
     return this.publishInternal(
       step.name,
       payload,
-      context,
+      options,
       this.logger.child({
         current: step.name,
         workflow: this.name,
@@ -171,11 +169,7 @@ export class Workflow {
   private async publishInternal<T extends WorkflowPayload>(
     message: string,
     payload: T | T[],
-    context:
-      | {
-          key?: string;
-        }
-      | undefined,
+    options: IMessageRoutingOptions | undefined,
     log: Logger
   ) {
     const payloadArray = Array.isArray(payload) ? payload : [payload];
@@ -189,12 +183,7 @@ export class Workflow {
 
       await Promise.all(
         payloadArray.map(data => {
-          const result = this.producer.send(
-            message,
-            data,
-            context?.key,
-            context
-          );
+          const result = this.producer.send(message, data, options);
 
           this.registry.emit('workflow_send', message, data);
 

--- a/packages/steveo/test/common/task_test.ts
+++ b/packages/steveo/test/common/task_test.ts
@@ -109,6 +109,6 @@ describe('Task', () => {
     const args = producerSendStub.args[0];
     expect(args[0]).to.equals(task.topic);
     expect(args[1]).to.deep.equals({ payload: 'something-small' });
-    expect(args[2]).to.equals('sample key');
+    expect(args[2]).to.eqls({ key: 'sample key' } );
   });
 });

--- a/packages/steveo/test/consumer/kafka_test.ts
+++ b/packages/steveo/test/consumer/kafka_test.ts
@@ -5,6 +5,7 @@ import Runner from '../../src/consumers/kafka';
 import { build } from '../../src/lib/pool';
 import Registry from '../../src/runtime/registry';
 import { getContext } from '../../src/lib/context';
+import {IMessageRoutingOptions} from "../../lib/common";
 
 describe('runner/kafka', () => {
   let sandbox;
@@ -135,7 +136,7 @@ describe('runner/kafka', () => {
       'commitMessage'
     );
     const expectedPayload: any = { attr: 'value' };
-    const messageContext: any = { any: 'context' };
+    const messageContext: IMessageRoutingOptions = { key: 'context' };
     const messagePayload: Buffer = Buffer.from(
       JSON.stringify({ ...expectedPayload, _meta: messageContext })
     );

--- a/packages/steveo/test/producer/kafka_test.ts
+++ b/packages/steveo/test/producer/kafka_test.ts
@@ -70,7 +70,7 @@ describe('Kafka Producer', () => {
       },
       registry
     );
-    const messageContext = { any: 'context' };
+    const messageContext = { key: 'random' };
     const messagePayload: any = { a: 'payload' };
     const expectedMessage = JSON.stringify({
       ...messagePayload,
@@ -78,7 +78,7 @@ describe('Kafka Producer', () => {
     });
 
     const sendStub = sandbox.stub(p.producer, 'produce').callsArgWith(5);
-    await p.send('test-topic', messagePayload, null, messageContext);
+    await p.send('test-topic', messagePayload, messageContext);
 
     const inputMessageBuffer: Buffer = sendStub.args[0][2];
     expect(inputMessageBuffer.toString()).to.be.equal(expectedMessage);

--- a/packages/steveo/test/producer/sqs_test.ts
+++ b/packages/steveo/test/producer/sqs_test.ts
@@ -248,7 +248,7 @@ describe('SQS Producer', () => {
       registry.addNewTask(task);
 
       const messagePayload: any = { a: 'payload' };
-      const messageContext: any = { key: 'context' };
+      const messageContext: IMessageRoutingOptions = { key: 'context' };
       const expectedMessageBody = {
         ...messagePayload,
         _meta: { ...createMessageMetadata(messagePayload), ...messageContext },
@@ -287,7 +287,7 @@ describe('SQS Producer', () => {
       registry.addNewTask(task);
 
       const messagePayload: any = { a: 'payload' };
-      const messageContext: any = { key: 'context' };
+      const messageContext: IMessageRoutingOptions = { key: 'context' };
       const expectedMessageBody = {
         ...messagePayload,
         _meta: { ...createMessageMetadata(messagePayload), ...messageContext },

--- a/packages/steveo/test/producer/sqs_test.ts
+++ b/packages/steveo/test/producer/sqs_test.ts
@@ -247,8 +247,7 @@ describe('SQS Producer', () => {
       registry.addNewTask(task);
 
       const messagePayload: any = { a: 'payload' };
-      const messageContext: any = { any: 'context' };
-      const messageGroupId: undefined = undefined;
+      const messageContext: any = { key: 'context' };
       const expectedMessageBody = {
         ...messagePayload,
         _meta: { ...createMessageMetadata(messagePayload), ...messageContext },
@@ -267,7 +266,6 @@ describe('SQS Producer', () => {
       await producer.send(
         'test-topic',
         messagePayload,
-        messageGroupId,
         messageContext
       );
       sinon.assert.calledWith(sendMessageStub, expectedPayload);
@@ -307,7 +305,6 @@ describe('SQS Producer', () => {
       await producer.send(
         'test-topic',
         messagePayload,
-        messageGroupId,
         messageContext
       );
       sinon.assert.calledWith(sendMessageStub, expectedPayload);


### PR DESCRIPTION
This PR adds support for using [ de-duplicating message ids for FIFO queues](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html).

In doing that, it does extend the usage of `context` in task publish methods. Renaming it to its intended usage.
- `context.key` is used for kafka message partitioning today. It will now also be used for [message grouping with FIFO queues](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagegroupid-property.html)
- `context.deDuplicationId` is added and will only be used for [deduplication of messages in FIFO queues](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html), otherwise ignored with other message libraries. 

Usage will look like the following:
```
await task.publish(payload, {
        key: 'schedule-run',
        deDuplicationId: `${scheduleId}-${schedule.sequence}`,
});
```

Note: publish typing is refactored for the above addition too.

