### PR TITLE
[Steveo] Type publish methods to enforce payloads to be object shaped

### DIFF
--- a/.changeset/gold-falcons-hammer.md
+++ b/.changeset/gold-falcons-hammer.md
@@ -1,0 +1,5 @@
+---
+"steveo": minor
+---
+
+Add type guards to publish methods (tasks and root instance)

--- a/packages/steveo/src/common.ts
+++ b/packages/steveo/src/common.ts
@@ -229,6 +229,11 @@ export interface ISteveo {
   producer: IProducer;
   task(topic: string, callBack: Callback, opts?: TaskOptions): ITask;
   runner(): IRunner;
+  publish: <T extends PayloadT>(
+    name: string,
+    payload: T,
+    options?: MessageRoutingOptions[keyof MessageRoutingOptions]
+  ) => Promise<void>;
 }
 
 export type AsyncWrapper = {
@@ -287,3 +292,5 @@ export interface Middleware {
 }
 
 export type sqsUrls = Record<string, string>;
+
+export type PayloadT = Record<string, any> | Record<string, any>[] | undefined;

--- a/packages/steveo/src/index.ts
+++ b/packages/steveo/src/index.ts
@@ -26,6 +26,7 @@ import {
   Middleware,
   MessageRoutingOptions,
   Configuration,
+  PayloadT,
 } from './common';
 import { Storage } from './types/storage';
 import { TaskOptions } from './types/task-options';
@@ -177,7 +178,7 @@ export class Steveo<E extends Configuration['engine'] = any>
    * Publish the given payload to the given topic
    * @param key
    */
-  async publish<T = any>(
+  async publish<T extends PayloadT = Record<string, any>>(
     name: string,
     payload: T,
     options?: MessageRoutingOptions[E]

--- a/packages/steveo/src/index.ts
+++ b/packages/steveo/src/index.ts
@@ -141,11 +141,14 @@ export class Steveo<E extends Configuration['engine'] = any>
    * @param options
    * @returns
    */
-  task<T = any, R = any, C = any>(
-    name: string,
-    callback: Callback<T, R, C>,
-    options: TaskOptions = {}
-  ) {
+  task<
+    T extends Record<string, any> | Record<string, any>[] | undefined = Record<
+      string,
+      any
+    >,
+    R = any,
+    C = any
+  >(name: string, callback: Callback<T, R, C>, options: TaskOptions = {}) {
     const queueFormatOptions: QueueFormatOptions = {
       queueName: options.queueName,
       upperCaseNames: this.config.upperCaseNames,

--- a/packages/steveo/src/index.ts
+++ b/packages/steveo/src/index.ts
@@ -142,14 +142,11 @@ export class Steveo<E extends Configuration['engine'] = any>
    * @param options
    * @returns
    */
-  task<
-    T extends Record<string, any> | Record<string, any>[] | undefined = Record<
-      string,
-      any
-    >,
-    R = any,
-    C = any
-  >(name: string, callback: Callback<T, R, C>, options: TaskOptions = {}) {
+  task<T extends PayloadT = Record<string, any>, R = any, C = any>(
+    name: string,
+    callback: Callback<T, R, C>,
+    options: TaskOptions = {}
+  ) {
     const queueFormatOptions: QueueFormatOptions = {
       queueName: options.queueName,
       upperCaseNames: this.config.upperCaseNames,

--- a/packages/steveo/src/runtime/task.ts
+++ b/packages/steveo/src/runtime/task.ts
@@ -9,14 +9,12 @@ import {
   IRegistry,
   MessageRoutingOptions,
   Configuration,
+  PayloadT,
 } from '../common';
 import { TaskOptions } from '../types/task-options';
 
 class Task<
-  T extends Record<string, any> | Record<string, any>[] | undefined = Record<
-    string,
-    any
-  >,
+  T extends PayloadT = Record<string, any>,
   R = any,
   E extends Configuration['engine'] = any
 > implements ITask<T, R>

--- a/packages/steveo/src/runtime/task.ts
+++ b/packages/steveo/src/runtime/task.ts
@@ -12,8 +12,14 @@ import {
 } from '../common';
 import { TaskOptions } from '../types/task-options';
 
-class Task<T = any, R = any, E extends Configuration['engine'] = any>
-  implements ITask<T, R>
+class Task<
+  T extends Record<string, any> | Record<string, any>[] | undefined = Record<
+    string,
+    any
+  >,
+  R = any,
+  E extends Configuration['engine'] = any
+> implements ITask<T, R>
 {
   config:
     | KafkaConfiguration


### PR DESCRIPTION
This PR types publish methods on [Task](https://github.com/ordermentum/steveo/blob/main/packages/steveo/src/runtime/task.ts#L15) and the [root Steveo instance](https://github.com/ordermentum/steveo/blob/main/packages/steveo/src/index.ts#L177) to only support object shaped payloads.

[This breaks kafka tasks being able to accept strings](https://github.com/ordermentum/steveo/blob/main/packages/steveo/src/producers/kafka.ts#L85) but it had 2 issues: 
- It didn't support adding tracing info on messages
- Trust boundary was violated. Kafka runner assumed it received valid strings. 

This change will give us better protection when publishing payloads on sqs/kafka tasks.