### PR TITLE
[DevX-173] [Steveo] Fix runtime duration calculation

### DIFF
--- a/.changeset/afraid-toes-mate.md
+++ b/.changeset/afraid-toes-mate.md
@@ -1,0 +1,5 @@
+---
+"steveo": minor
+---
+
+Change duration calculation in task runs [Steveo]

--- a/packages/steveo/src/consumers/sqs.ts
+++ b/packages/steveo/src/consumers/sqs.ts
@@ -125,13 +125,16 @@ class SqsRunner extends BaseRunner implements IRunner {
 
       logger.debug('Completed subscribe');
 
-      const completedContext = getContext(payload);
-
       if (waitToCommit) {
         await this.deleteMessage(topic, message);
       }
 
-      this.registry.emit('runner_complete', topic, payload, completedContext);
+      this.registry.emit(
+        'runner_complete',
+        topic,
+        payload,
+        getContext(payload)
+      );
     } catch (error) {
       logger.error(
         {

--- a/packages/steveo/src/lib/context.ts
+++ b/packages/steveo/src/lib/context.ts
@@ -38,7 +38,7 @@ export const getContext = params => {
 
   // 0 lets us filter out messages that don't have a start time
   let duration: number = 0;
-  if (meta) {
+  if (meta?.start) {
     duration = getDuration(meta.start);
   }
 

--- a/packages/steveo/src/lib/context.ts
+++ b/packages/steveo/src/lib/context.ts
@@ -13,25 +13,30 @@ export const createMessageMetadata = <T = any>(message: T) => {
     .digest('hex')
     .substring(0, 8);
   const timestamp = moment().unix();
-  const start = process.hrtime();
+  /**
+   * Normally, you'll use the `process.hrtime()` method to get the current high-resolution real time in a [seconds, nanoseconds] tuple Array.
+   * Since messages can pass process boundaries, we'll use the `Date.now()` method to get the current Unix timestamp.
+   *
+   * We lose resolution against `process.hrtime()` (Nanoseconds v/s Milliseconds), but we gain consistency across processes since hrtime is relative to the process start time.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now
+   * @see https://nodejs.org/api/process.html#process_process_hrtime_time
+   *
+   * Note: Date.now() can also differ between processes, but it's a better choice than process.hrtime() for our use case.
+   * Ideally, we'll sync the time across all services using NTP.
+   */
+  const start = Date.now(); // Milliseconds since Unix epoch
   const hostname = os.hostname();
 
   return { ..._meta, hostname, timestamp, signature, start };
 };
 
-export const getDuration = (
-  start: [number, number] | undefined = undefined
-): number => {
-  const durationComponents: [number, number] = process.hrtime(start);
-  const seconds: number = durationComponents[0];
-  const nanoseconds: number = durationComponents[1];
-
-  return seconds * 1000 + nanoseconds / 1e6;
-};
+export const getDuration = (startMs: number) => Date.now() - startMs;
 
 export const getContext = params => {
   const { _meta: meta = {} } = params;
 
+  // 0 lets us filter out messages that don't have a start time
   let duration: number = 0;
   if (meta) {
     duration = getDuration(meta.start);

--- a/packages/steveo/src/lib/context.ts
+++ b/packages/steveo/src/lib/context.ts
@@ -38,7 +38,8 @@ export const getContext = params => {
 
   // 0 lets us filter out messages that don't have a start time
   let duration: number = 0;
-  if (meta?.start) {
+  // Array check is to ignore in-flight messages with a start time emitted by the process.hrtime() method
+  if (meta?.start && !Array.isArray(meta.start)) {
     duration = getDuration(meta.start);
   }
 


### PR DESCRIPTION
Steveo consumers emit `runner_complete` event with a `duration` in the context argument. 
Duration is meant to be the time elapsed from `producer producing the message -> consumer processing and running the task`

The api used to calculate the diff `process.hrtime` is not synced across node processes. Which means the event duration is not accurate. It's the reason [we see negative values as duration.](https://app.datadoghq.com/logs?query=@topic:PRODUCTION_ORDER-SCHEDULE-PLACEMENT%20@metric_name:runner_success_ms&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=service,@kubernetes.pod_name&event=AwAAAZSwF2VlTBCMUwAAABhBWlN3RjJWbEFBQXdaaGI0eFZNWC1nSkcAAAAkMDE5NGIwMTctNjU2NS00YjQyLTk2ZTMtYTE4NTQ5OWQxZjM2AAAFZw&fromUser=true&index=metrics&messageDisplay=expanded-lg&storage=hot&stream_sort=desc&viz=stream&from_ts=1737936246490&to_ts=1738109046490&live=true)

This PR changes the api to `Date.now()`. Even though its resolution is worse (millisecond vs nanosecond), one can assume it's reasonably consistent across node processes.

Duration was always emitted in milliseconds, so no change there. 

Note: In flight messages will produce `duration = 0` till they are exhausted but it's no different than garbage values.