### PR TITLE
[DevX-173] [Steveo] Make duration calculation backwards compatible

### DIFF
--- a/packages/steveo/src/lib/context.ts
+++ b/packages/steveo/src/lib/context.ts
@@ -13,6 +13,7 @@ export const createMessageMetadata = <T = any>(message: T) => {
     .digest('hex')
     .substring(0, 8);
   const timestamp = moment().unix();
+  const start = process.hrtime();
   /**
    * Normally, you'll use the `process.hrtime()` method to get the current high-resolution real time in a [seconds, nanoseconds] tuple Array.
    * Since messages can pass process boundaries, we'll use the `Date.now()` method to get the current Unix timestamp.
@@ -25,10 +26,10 @@ export const createMessageMetadata = <T = any>(message: T) => {
    * Note: Date.now() can also differ between processes, but it's a better choice than process.hrtime() for our use case.
    * Ideally, we'll sync the time across all services using NTP.
    */
-  const start = Date.now(); // Milliseconds since Unix epoch
+  const startMs = Date.now(); // Milliseconds since Unix epoch
   const hostname = os.hostname();
 
-  return { ..._meta, hostname, timestamp, signature, start };
+  return { ..._meta, hostname, timestamp, signature, start, startMs };
 };
 
 export const getDuration = (startMs: number) => Date.now() - startMs;
@@ -39,8 +40,8 @@ export const getContext = params => {
   // 0 lets us filter out messages that don't have a start time
   let duration: number = 0;
   // Array check is to ignore in-flight messages with a start time emitted by the process.hrtime() method
-  if (meta?.start && !Array.isArray(meta.start)) {
-    duration = getDuration(meta.start);
+  if (meta?.startMs) {
+    duration = getDuration(meta.startMs);
   }
 
   return { ...meta, duration };

--- a/packages/steveo/test/consumer/kafka_test.ts
+++ b/packages/steveo/test/consumer/kafka_test.ts
@@ -412,7 +412,7 @@ describe('runner/kafka', () => {
 
   it('calculates duration of a task run correctly', async () => {
     clock.restore();
-    const start = Date.now();
+    const startMs = Date.now();
     const subscribeStub = sinon
       .stub()
       .returns(Promise.resolve({ some: 'success' }));
@@ -443,7 +443,7 @@ describe('runner/kafka', () => {
       'commitMessage'
     );
     const expectedPayload: any = { attr: 'value' };
-    const messageContext = { key: 'context', start };
+    const messageContext = { key: 'context', startMs };
     const messagePayload: Buffer = Buffer.from(
       JSON.stringify({ ...expectedPayload, _meta: messageContext })
     );

--- a/packages/steveo/test/consumer/sqs_test.ts
+++ b/packages/steveo/test/consumer/sqs_test.ts
@@ -614,7 +614,7 @@ describe('runner/sqs', () => {
 
   it('calculates duration of a task run correctly', async () => {
     clock.restore();
-    const start = Date.now();
+    const startMs = Date.now();
     const subscribeStub = sandbox.stub().resolves({ some: 'success' });
     const anotherRegistry = {
       registeredTasks: [],
@@ -653,7 +653,7 @@ describe('runner/sqs', () => {
       // @ts-ignore
       .returns({ promise: async () => {} });
 
-    const inputContext = { contextKey: 'contextValue', start };
+    const inputContext = { contextKey: 'contextValue', startMs };
     const messageBody = { data: 'Hello', _meta: inputContext };
 
     // Wait a second to avoid flakiness


### PR DESCRIPTION
Companion change to https://github.com/ordermentum/steveo/pull/863

Adding a new field to not break service to service processing.

`process.hrtime` throws an exception if a wrong argument is passed

```sh
> process.hrtime(12321312)
Uncaught:
TypeError [ERR_INVALID_ARG_TYPE]: The "time" argument must be an instance of Array. Received type number (12321312)
    at process.hrtime (node:internal/process/per_thread:74:5) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```