### PR TITLE
[DevX-183] Add rebalancing logic to kafka consumers

### DIFF
--- a/.changeset/ten-buses-appear.md
+++ b/.changeset/ten-buses-appear.md
@@ -1,0 +1,6 @@
+---
+"@steveojs/storage-postgres": major
+"steveo": major
+---
+
+Upgrade node-rdkafka, add custom rebalancing

--- a/apps/tasks-example/package.json
+++ b/apps/tasks-example/package.json
@@ -15,7 +15,7 @@
     "lodash.merge": "^4.6.2",
     "lodash.shuffle": "^4.2.0",
     "moment": "2.30.1",
-    "node-rdkafka": "^2.11.0",
+    "node-rdkafka": "^3.2.1",
     "null-logger": "^2.0.0",
     "rsmq": "^0.12.3",
     "uuid": "^3.1.0"

--- a/apps/workflows-example/package.json
+++ b/apps/workflows-example/package.json
@@ -38,7 +38,7 @@
     "lodash.merge": "^4.6.2",
     "lodash.shuffle": "^4.2.0",
     "moment": "2.30.1",
-    "node-rdkafka": "^2.11.0",
+    "node-rdkafka": "^3.2.1",
     "null-logger": "^2.0.0",
     "rsmq": "^0.12.3",
     "ts-dotenv": "^0.9.1",

--- a/packages/steveo/package.json
+++ b/packages/steveo/package.json
@@ -49,7 +49,7 @@
     "lodash.merge": "4.6.2",
     "lodash.shuffle": "^4.2.0",
     "moment": "2.30.1",
-    "node-rdkafka": "2.18.0",
+    "node-rdkafka": "^3.2.1",
     "null-logger": "^2.0.0",
     "rsmq": "^0.12.4",
     "uuid": "^9.0.0"

--- a/packages/steveo/src/config.ts
+++ b/packages/steveo/src/config.ts
@@ -13,6 +13,15 @@ const KafkaConsumerDefault: KafkaConsumerConfig = {
     'socket.keepalive.enable': true,
     'enable.auto.commit': false,
     'group.id': 'KAFKA_CONSUMERS',
+    /**
+     * See: https://www.confluent.io/blog/incremental-cooperative-rebalancing-in-kafka/
+     * This is a new feature in Kafka 2.4.0 that allows consumers to join and leave the group
+     * without triggering a full rebalance. This can be useful for scaling out consumers in a
+     * consumer group without causing a rebalance of the entire group.
+     * The default value is 'eager' which means that the consumer will trigger a rebalance
+     * when it joins or leaves the group, which is STOP THE WORLD behavior.
+     */
+    'partition.assignment.strategy': 'cooperative-sticky',
   },
   topic: {
     'auto.offset.reset': 'latest',

--- a/packages/steveo/test/common/config_test.ts
+++ b/packages/steveo/test/common/config_test.ts
@@ -15,6 +15,7 @@ describe('Config', () => {
       'socket.keepalive.enable': true,
       'enable.auto.commit': false,
       'group.id': 'KAFKA_CONSUMERS',
+      'partition.assignment.strategy': 'cooperative-sticky',
     });
     expect(config.producer).to.eqls({ global: {}, topic: {} });
     expect(config.admin).to.eqls({});
@@ -55,6 +56,7 @@ describe('Config', () => {
       'socket.keepalive.enable': true,
       'enable.auto.commit': false,
       'group.id': 'TEST_CONSUMERS',
+      'partition.assignment.strategy': 'cooperative-sticky',
       a: 1,
     });
     expect(config.producer).to.eqls({

--- a/packages/storage-postgres/package.json
+++ b/packages/storage-postgres/package.json
@@ -53,7 +53,7 @@
     "lodash.merge": "4.6.2",
     "lodash.shuffle": "^4.2.0",
     "moment": "2.30.1",
-    "node-rdkafka": "2.18.0",
+    "node-rdkafka": "3.2.1",
     "null-logger": "^2.0.0",
     "prisma": "^5.19.1",
     "radash": "^12.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5231,10 +5231,15 @@ mv@~2:
     ncp "~2.0.0"
     rimraf "~2.4.0"
 
-nan@^2.14.0, nan@^2.16.0, nan@^2.17.0:
+nan@^2.14.0, nan@^2.16.0:
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.17.0.tgz#c0150a2368a182f033e9aa5195ec76ea41a199cb"
   integrity sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==
+
+nan@^2.19.0:
+  version "2.22.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.22.0.tgz#31bc433fc33213c97bad36404bb68063de604de3"
+  integrity sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==
 
 nanoid@3.1.23:
   version "3.1.23"
@@ -5336,13 +5341,13 @@ node-preload@^0.2.1:
   dependencies:
     process-on-spawn "^1.0.0"
 
-node-rdkafka@2.18.0:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-2.18.0.tgz#116950e49dfe804932c8bc6dbc68949793e72ee2"
-  integrity sha512-jYkmO0sPvjesmzhv1WFOO4z7IMiAFpThR6/lcnFDWgSPkYL95CtcuVNo/R5PpjujmqSgS22GMkL1qvU4DTAvEQ==
+node-rdkafka@3.2.1, node-rdkafka@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-3.2.1.tgz#1e41ed61e88c551745ca9de097c9e64a7cb1803d"
+  integrity sha512-lf/U8LLCLA8v2tAh2x4guizfFAZSt/KJSzzaIEXtYGospfeZVf2U0RfHlCo7+XvbUoAG4V3uyMgif/tjHQIYfA==
   dependencies:
     bindings "^1.3.1"
-    nan "^2.17.0"
+    nan "^2.19.0"
 
 node-releases@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
[Node-rdKafka won't handle rebalancing state](https://github.com/Blizzard/node-rdkafka/blob/master/lib/kafka-consumer.js#L49-L97) and leaves it to lib-rdkafka to do it. 

There are issues we are observing with this approach: [Link to logs where consumers are left in a Zombie state and they don't process anything even though they are connected to Kafka](https://app.datadoghq.com/logs?query=%22Broker%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZSxarUkS2Ut_wAAABhBWlN4YXJpckFBQlNCRkpNZHJkQ1BnQ0IAAAAkMDE5NGIxODAtZGNmZS00ZWY2LTg3YWYtM2E1ZGZhM2U0YTMyAAOVbQ&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1737595743146&to_ts=1738200543146&live=true)

Other solutions rebalance on specific error codes: https://github.com/tulios/kafkajs/pull/1474

This PR:
- Adds rebalancing callback to assign and unassign partitions on the consumer
- [Adds incremental assign and unassign rebalance protocol support](https://www.confluent.io/blog/incremental-cooperative-rebalancing-in-kafka/). This replaces [EAGER rebalancing approach](https://www.confluent.io/blog/cooperative-rebalancing-in-kafka-streams-consumer-ksqldb/) which is STOP THE WORLD rebalancing
- Makes incremental rebalancing default for consumers
- Upgrades node-rdkafka to 3.2.1

More reading:
- https://github.com/Blizzard/node-rdkafka/pull/1081
- https://github.com/apache/kafka/blob/2.6.1/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java 
- https://github.com/Blizzard/node-rdkafka/issues/887
