### PR TITLE
Kafka - Revert to non eager partition strategy

### DIFF
--- a/.changeset/good-beds-tease.md
+++ b/.changeset/good-beds-tease.md
@@ -1,0 +1,5 @@
+---
+"steveo": patch
+---
+
+Revert default partitioning strategy to non-eager [Kafka]

--- a/packages/steveo/package.json
+++ b/packages/steveo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steveo",
-  "version": "8.1.0-beta",
+  "version": "8.1.0",
   "description": "A Task Pub/Sub Background processing library",
   "main": "lib/index.js",
   "author": "engineering@ordermentum.com",

--- a/packages/steveo/package.json
+++ b/packages/steveo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steveo",
-  "version": "8.1.0",
+  "version": "8.1.0-beta",
   "description": "A Task Pub/Sub Background processing library",
   "main": "lib/index.js",
   "author": "engineering@ordermentum.com",

--- a/packages/steveo/src/config.ts
+++ b/packages/steveo/src/config.ts
@@ -13,15 +13,6 @@ const KafkaConsumerDefault: KafkaConsumerConfig = {
     'socket.keepalive.enable': true,
     'enable.auto.commit': false,
     'group.id': 'KAFKA_CONSUMERS',
-    /**
-     * See: https://www.confluent.io/blog/incremental-cooperative-rebalancing-in-kafka/
-     * This is a new feature in Kafka 2.4.0 that allows consumers to join and leave the group
-     * without triggering a full rebalance. This can be useful for scaling out consumers in a
-     * consumer group without causing a rebalance of the entire group.
-     * The default value is 'eager' which means that the consumer will trigger a rebalance
-     * when it joins or leaves the group, which is STOP THE WORLD behavior.
-     */
-    'partition.assignment.strategy': 'cooperative-sticky',
   },
   topic: {
     'auto.offset.reset': 'latest',

--- a/packages/steveo/src/consumers/kafka.ts
+++ b/packages/steveo/src/consumers/kafka.ts
@@ -42,7 +42,7 @@ class KafkaRunner
       {
         'bootstrap.servers': this.config.bootstrapServers,
         'security.protocol': this.config.securityProtocol,
-        rebalance_cb(err, assignment) {
+        rebalance_cb: (err, assignment) => {
           this.logger.debug('Rebalance event', err, assignment);
           try {
             /**
@@ -61,17 +61,10 @@ class KafkaRunner
                 Kafka.CODES.ERRORS.ERR_UNKNOWN_MEMBER_ID,
               ].includes(err.code)
             ) {
-              if (this.consumer.rebalanceProtocol() === 'COOPERATIVE') {
-                this.consumer.incrementalAssign(assignment);
-              } else {
-                this.consumer.assign(assignment);
-              }
+              //
+              this.consumer.assign(assignment);
             } else if (err.code === Kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS) {
-              if (this.consumer.rebalanceProtocol() === 'COOPERATIVE') {
-                this.consumer.incrementalUnassign(assignment);
-              } else {
-                this.consumer.unassign();
-              }
+              this.consumer.unassign();
             }
           } catch (e) {
             this.logger.error('Error during rebalance', e);

--- a/packages/steveo/src/consumers/kafka.ts
+++ b/packages/steveo/src/consumers/kafka.ts
@@ -42,7 +42,7 @@ class KafkaRunner
       {
         'bootstrap.servers': this.config.bootstrapServers,
         'security.protocol': this.config.securityProtocol,
-        rebalance_cb: (err, assignment) => {
+        rebalance_cb(err, assignment) {
           this.logger.debug('Rebalance event', err, assignment);
           try {
             /**

--- a/packages/steveo/test/common/config_test.ts
+++ b/packages/steveo/test/common/config_test.ts
@@ -15,7 +15,6 @@ describe('Config', () => {
       'socket.keepalive.enable': true,
       'enable.auto.commit': false,
       'group.id': 'KAFKA_CONSUMERS',
-      'partition.assignment.strategy': 'cooperative-sticky',
     });
     expect(config.producer).to.eqls({ global: {}, topic: {} });
     expect(config.admin).to.eqls({});
@@ -56,7 +55,6 @@ describe('Config', () => {
       'socket.keepalive.enable': true,
       'enable.auto.commit': false,
       'group.id': 'TEST_CONSUMERS',
-      'partition.assignment.strategy': 'cooperative-sticky',
       a: 1,
     });
     expect(config.producer).to.eqls({

--- a/yarn.lock
+++ b/yarn.lock
@@ -7080,6 +7080,29 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
+steveo@*:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/steveo/-/steveo-8.1.0.tgz#84c0318f888d12c566d861797d405886619b412c"
+  integrity sha512-eWZkx00h+b9ogCeZmteNbE40JMhhpXlZ9ZecrfZBFrj1aYe8Fq1/0G2tKiOEfAl2W9xFc2FHFR/XXKBIvLSL5Q==
+  dependencies:
+    "@aws-sdk/client-sqs" "^3.637.0"
+    "@smithy/node-http-handler" "^3.1.4"
+    "@types/bluebird" "^3.5.38"
+    bluebird "^3.7.2"
+    generic-pool "^3.9.0"
+    husky "^9.1.7"
+    lazy-object "^1.0.1"
+    lint-staged "^15.4.3"
+    lodash.difference "^4.5.0"
+    lodash.intersection "^4.4.0"
+    lodash.merge "4.6.2"
+    lodash.shuffle "^4.2.0"
+    moment "2.30.1"
+    node-rdkafka "^3.2.1"
+    null-logger "^2.0.0"
+    rsmq "^0.12.4"
+    uuid "^9.0.0"
+
 string-argv@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"


### PR DESCRIPTION
Changing partition strategy for a group with consumers is not possible if they are actively used.

For reference, look at [Logs](https://app.datadoghq.com/logs?query=service%3Aordermentum-job%20%40level%3Aerror%20%22Error%20while%20consumption%20-%20Error%3A%20Broker%3A%20Inconsistent%20group%20protocol%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=%40kubernetes.pod_name&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1738903867454&to_ts=1738904522000&live=false)

Also simplify rebalancing algorithm