### PR TITLE
[DevX-200] Drain consumer resource pools when shutting down

### DIFF
--- a/.changeset/sour-cougars-relax.md
+++ b/.changeset/sour-cougars-relax.md
@@ -1,0 +1,5 @@
+---
+"steveo": minor
+---
+
+Drain resource pools when steveo instances shuts down

--- a/packages/steveo/src/consumers/sqs.ts
+++ b/packages/steveo/src/consumers/sqs.ts
@@ -256,7 +256,6 @@ class SqsRunner extends BaseRunner implements IRunner {
           try {
             await this.receive(messages, topic);
           } catch (ex) {
-            console.log('$$$$$$$$$$$', ex);
             this.logger.error('Error while invoking receive', {
               error: ex,
               topic,

--- a/packages/steveo/src/consumers/sqs.ts
+++ b/packages/steveo/src/consumers/sqs.ts
@@ -235,6 +235,9 @@ class SqsRunner extends BaseRunner implements IRunner {
     await bluebird.map(
       subscriptions,
       async topic => {
+        // If the consumer is supposed to terminate
+        // do not process any more messages
+        if (this.manager.shouldTerminate) return;
         const queueURL: string = await this.getQueueUrl(topic);
         if (queueURL) {
           this.logger.debug(`starting processing of ${topic} with ${queueURL}`);
@@ -253,6 +256,7 @@ class SqsRunner extends BaseRunner implements IRunner {
           try {
             await this.receive(messages, topic);
           } catch (ex) {
+            console.log('$$$$$$$$$$$', ex);
             this.logger.error('Error while invoking receive', {
               error: ex,
               topic,

--- a/packages/steveo/src/lib/manager.ts
+++ b/packages/steveo/src/lib/manager.ts
@@ -28,15 +28,57 @@ export class Manager {
     this.state = 'paused';
   }
 
-  // allow runner and producer to gracefully stop processing
-  async stop() {
-    this.logger.debug(`signal runner and producer to terminate`);
-    await Promise.all([
-      this.steveo.runner().stop(),
-      this.steveo.producer.stop(),
-    ]);
+  /**
+   * Drain and clear the pools managed by global.steveo.
+   *
+   * @private
+   */
+  async _drainAndClearPools() {
+    // Steveo maintains a list of pools that need to be drained and cleared
+    // Look at packages/steveo/src/lib/pool.ts for more info
+    const pools = global.steveo?.pools;
 
-    await this.shutdown();
+    if (!pools || pools.length === 0) {
+      return;
+    }
+
+    await Promise.all(
+      pools.map(async (pool) => {
+        try {
+          if (pool.borrowed > 0) {
+            await pool.drain();
+            await pool.clear();
+          }
+        } catch (error) {
+          this.logger.error('Error draining and clearing pool', error);
+        }
+      })
+    );
+  }
+
+  /**
+   * Gracefully shuts down the system by stopping the runner, producer, and draining/clearing any active pools.
+   *
+   * - Signals the runner to terminate
+   * - Initiates the shutdown, which waits for a set amount of time before force terminating the runner.
+   * - If there are any active pools managed by Steveo, it ensures that:
+   *    1. All borrowed items are drained from the pool.
+   *    2. The pool is cleared to prevent any lingering resources.
+   * - Signals the producer to terminate
+   * - Handles any errors that occur during the draining/clearing process.
+   *
+   */
+  async stop() {
+    this.logger.debug('signal runner to terminate');
+    await Promise.all(
+      [
+        this.steveo.runner().stop(),
+        this.shutdown()
+      ]
+    );
+    await this._drainAndClearPools();
+    this.logger.debug('signal producer to terminate');
+    await this.steveo.producer.stop();
   }
 
   async shutdown() {

--- a/packages/steveo/src/lib/pool.ts
+++ b/packages/steveo/src/lib/pool.ts
@@ -1,10 +1,17 @@
-import genericPool, { Options } from 'generic-pool';
+import genericPool, {Options, Pool} from 'generic-pool';
 import { v4 } from 'uuid';
 import Registry from '../runtime/registry';
 
 export type Resource = {
   id: string;
 };
+
+declare global {
+  var steveo: {
+    pools: Pool<Resource>[]
+  } | undefined;
+}
+
 
 export class ConsumerPool {
   registry: Registry;
@@ -25,5 +32,18 @@ export class ConsumerPool {
 }
 
 export function build(registry: Registry, options: Options = {}) {
-  return genericPool.createPool<Resource>(new ConsumerPool(registry), options);
+  const pool = genericPool.createPool<Resource>(new ConsumerPool(registry), options);
+  /**
+   * Steveo maintains a list of pools that need to be drained and cleared
+   * Look at packages/steveo/src/lib/manager.ts for shutdown logic
+   * This needs to be globally available for multiple steveo instances in a single process
+   */
+  if(!global.steveo?.pools)
+    global.steveo = {
+      pools: [pool]
+    };
+  else
+    global.steveo.pools.push(pool);
+
+  return pool;
 }

--- a/packages/steveo/test/index_test.ts
+++ b/packages/steveo/test/index_test.ts
@@ -2,13 +2,14 @@ import logger from 'pino';
 import Bluebird from 'bluebird';
 import { expect } from 'chai';
 import { promisify } from 'util';
+import { randomUUID } from 'crypto';
 import { KafkaConfiguration, Steveo } from '../src';
 
 const sleep = promisify(setTimeout);
 
 describe('Steveo Integration Test', () => {
   it('gracefully shuts itself down when multiple steveo instances are running and are dependent on each other', async () => {
-    const consumerGroupId = 'steveo-integration-test';
+    const consumerGroupId = `steveo-integration-test-${randomUUID()}`;
 
     const kafkaConfiguration: KafkaConfiguration = {
       engine: 'kafka' as const,
@@ -64,7 +65,7 @@ describe('Steveo Integration Test', () => {
       kafkaConfiguration,
       log.child({ engine: 'kafka' })
     );
-    const tasks = ['one', 'two', 'three'];
+    const tasks = [randomUUID(), randomUUID(), randomUUID()];
 
     kafka.task('steveo_integration_noop_task', async () => {
       log.info('noop task');
@@ -111,6 +112,122 @@ describe('Steveo Integration Test', () => {
     });
 
     await sleep(5000);
+
+    await Promise.all([sqs.stop(), kafka.stop()]);
+
+    await sleep(1000);
+
+    expect(receivedProducerFailure).to.equal(false);
+    expect(receivedTerminate).to.equal(true);
+    expect(sqs.manager.state).to.equal('terminated');
+    expect(kafka.manager.state).to.equal('terminated');
+  });
+
+  it('waits for the consumer pool to drain before shutting down completely', async () => {
+    const consumerGroupId = `steveo-integration-test-${randomUUID()}`;
+
+    const kafkaConfiguration: KafkaConfiguration = {
+      engine: 'kafka' as const,
+      queuePrefix: `steveo`,
+      shuffleQueue: false,
+      bootstrapServers: '0.0.0.0:9092',
+      defaultTopicReplicationFactor: 1,
+      tasksPath: '.',
+      securityProtocol: 'plaintext',
+      consumer: {
+        global: {
+          'group.id': consumerGroupId,
+        },
+        topic: {},
+      },
+      producer: {
+        global: {},
+        topic: {},
+      },
+      waitToCommit: true,
+      upperCaseNames: true,
+      middleware: [],
+    };
+
+    const sqsConfiguration = {
+      region: 'us-east-1',
+      apiVersion: '2012-11-05',
+      receiveMessageWaitTimeSeconds: '20',
+      messageRetentionPeriod: '604800',
+      engine: 'sqs' as const,
+      queuePrefix: `steveo`,
+      credentials: {
+        accessKeyId: 'test',
+        secretAccessKey: 'key',
+      },
+      shuffleQueue: false,
+      endpoint: 'http://127.0.0.1:4566',
+      maxNumberOfMessages: 1,
+      workerConfig: {
+        max: 2,
+      },
+      visibilityTimeout: 180,
+      waitTimeSeconds: 2,
+      consumerPollInterval: 500,
+      upperCaseNames: true,
+      middleware: [],
+      tasksPath: '.',
+    };
+
+    const log = logger({ level: 'debug' });
+    const sqs = new Steveo(sqsConfiguration, log.child({ engine: 'sqs' }));
+    const kafka = new Steveo(
+      kafkaConfiguration,
+      log.child({ engine: 'kafka' })
+    );
+    const tasks = [randomUUID(), randomUUID(), randomUUID()];
+
+    kafka.task('steveo_integration_noop_task', async () => {
+      log.info('noop task');
+    });
+
+    /**
+     * create a dependency between the two steveo instances
+     */
+    for (const task of tasks) {
+      sqs.task(`steveo_integration_${task}`, async () => {
+        await sleep(5000); // simulate a long-running task
+        await kafka.publish('steveo_integration_noop_task', {});
+      });
+    }
+
+    await Promise.all([
+      sqs.runner().createQueues(),
+      kafka.runner().createQueues(),
+    ]);
+
+    await Promise.all([sqs.start(), kafka.start()]);
+    await kafka.producer.initialize();
+
+    const iterations = 3;
+    await Bluebird.map(
+      Array(iterations).fill(0),
+      async () => {
+        const randomTask = tasks[Math.floor(Math.random() * tasks.length)];
+        await sqs.publish(`steveo_integration_${randomTask}`, {});
+      },
+      { concurrency: 3 }
+    );
+
+    sqs.runner().process();
+    kafka.runner().process();
+
+    let receivedProducerFailure = false;
+    kafka.registry.events.on('producer_failure', () => {
+      receivedProducerFailure = true;
+    });
+
+    let receivedTerminate = false;
+    sqs.registry.events.on('terminate', () => {
+      receivedTerminate = true;
+    });
+
+    await sleep(3000);
 
     await Promise.all([sqs.stop(), kafka.stop()]);
 


### PR DESCRIPTION
This PR adds pool draining when steveo instances shutdown. 

Pools are pushed onto the global object on the NodeJs process so they can be drained when multiple steveo instances shutdown concurrently. 

Draining allows steveo instances to wait for each other resources to release before they can disconnect each other's producers.  (_Think SQS task -> publishing to Kafka or vice versa_)

