### PR TITLE
Stop SQS consumer to process messages when shutting down

### DIFF
--- a/.changeset/eleven-needles-hide.md
+++ b/.changeset/eleven-needles-hide.md
@@ -1,0 +1,5 @@
+---
+"steveo": patch
+---
+
+Improve graceful shutdown for sqs consumers - Steveo

--- a/packages/steveo/src/consumers/sqs.ts
+++ b/packages/steveo/src/consumers/sqs.ts
@@ -91,6 +91,10 @@ class SqsRunner extends BaseRunner implements IRunner {
     payload: PayLoad,
     logger: Logger
   ): Promise<void> {
+    // If the consumer is supposed to terminate
+    // do not process any more messages
+    if (this.manager.shouldTerminate) return;
+
     const resource = await this.pool.acquire();
     const { _meta: _, ...data } = payload;
 


### PR DESCRIPTION
Follow on change from:
https://github.com/ordermentum/steveo/pull/892
https://github.com/ordermentum/steveo/pull/868

This PR adds an additional check just before the SQS consumer starts processing a message to bail out if the steveo instance is supposed to shut down.

This is an edge case for applications that run multiple instances of steveo and have interdependent task (think sqs consumers publishing to kafka) and they are about to shut down. 