### PR TITLE
Add termination fix to sequelize terminate

### DIFF
--- a/.changeset/icy-towns-decide.md
+++ b/.changeset/icy-towns-decide.md
@@ -1,0 +1,5 @@
+---
+"@steveojs/scheduler-prisma": minor
+---
+
+Fix scheduler terminate gracefully

--- a/.changeset/tame-rings-double.md
+++ b/.changeset/tame-rings-double.md
@@ -1,0 +1,5 @@
+---
+"@steveojs/scheduler-sequelize": minor
+---
+
+Fix for sequelize scheduler graceful termination

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,14 @@
+version = 1
+
+test_patterns = ["test/**"]
+
+exclude_patterns = ["migrations/**"]
+
+[[analyzers]]
+name = "javascript"
+
+  [analyzers.meta]
+  environment = [
+    "nodejs",
+    "mocha"
+  ]

--- a/packages/scheduler-prisma/src/utils/wait.ts
+++ b/packages/scheduler-prisma/src/utils/wait.ts
@@ -1,0 +1,45 @@
+/**
+ * Waits for a specified amount of time
+ * @param ms - The amount of time to wait in milliseconds
+ * @returns A promise that resolves after the specified time has elapsed
+ */
+export function waitTime(ms: number): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/**
+ * Waits for a condition to change
+ * @param fn - The condition to wait for
+ * @param timeout - The maximum amount of time to wait in milliseconds
+ * @param interval - The interval at which to check the condition in milliseconds
+ * @returns A promise that resolves when the condition changes
+ */
+export function waitForChange(
+  fn: () => boolean,
+  timeout = 5000,
+  interval = 50
+) {
+  return new Promise(resolve => {
+    const startTime = Date.now();
+
+    const checkCondition = () => {
+      if (fn()) {
+        resolve(true);
+        return;
+      }
+
+      // If timeout has been exceeded, reject with an error.
+      if (Date.now() - startTime > timeout) {
+        resolve(false);
+        return;
+      }
+
+      // Otherwise, check again after the specified interval.
+      setTimeout(checkCondition, interval);
+    };
+
+    checkCondition();
+  });
+}

--- a/packages/scheduler-prisma/test/.eslintrc
+++ b/packages/scheduler-prisma/test/.eslintrc
@@ -2,9 +2,6 @@
   "extends": [
     "@ordermentum/ordermentum/mocha",
     "@ordermentum/ordermentum/jest"
-  ],
-  "parserOptions": {
-    "project": "../tsconfig.test.json"
-  }
+  ]
 }
 

--- a/packages/scheduler-prisma/test/fixtures/test_scheduler.fixture.ts
+++ b/packages/scheduler-prisma/test/fixtures/test_scheduler.fixture.ts
@@ -1,0 +1,26 @@
+import { createLogger } from 'bunyan';
+import { SinonSandbox } from 'sinon';
+import { PrismaClient } from '@prisma/client';
+import { JobScheduler, Tasks } from '../../src/index';
+
+/**
+ * Factory that creates a new JobScheduler instance for testing purposes
+ */
+export function createTestScheduler(
+  sandbox: SinonSandbox,
+  props: { tasks: Tasks }
+) {
+  const logger = createLogger({ name: 'test-scheduler' });
+  const mockPrisma = sandbox.createStubInstance(PrismaClient);
+
+  // sandbox.stub(models, 'default').callsFake(initSequelizeStub);
+
+  return new JobScheduler({
+    client: mockPrisma,
+    logger,
+    jobsSafeToRestart: [],
+    jobsRiskyToRestart: [],
+    jobsCustomRestart: {},
+    tasks: props.tasks,
+  });
+}

--- a/packages/scheduler-prisma/test/index_test.ts
+++ b/packages/scheduler-prisma/test/index_test.ts
@@ -1,0 +1,65 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { createTestScheduler } from './fixtures/test_scheduler.fixture';
+import { waitForChange, waitTime } from '../src/utils/wait';
+
+describe('JobScheduler', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should wait for publish messages when terminated', async () => {
+    // ARRANGE
+
+    // This is the control latch between the task and the outer test.
+    let testTaskCompleted = false;
+
+    const scheduler = createTestScheduler(sandbox, {
+      tasks: {
+        test: async () => {
+          // Wait for the scheduler to start terminating
+          await waitForChange(() => scheduler.exiting);
+
+          // Wait for 100ms to allow the scheduler to terminate without
+          // waiting on this task if it's acting improperly.
+          await waitTime(100);
+
+          // Signal to the outer test that the task has completed
+          testTaskCompleted = true;
+
+          return Promise.resolve();
+        },
+      },
+    });
+
+    // This is intentionally doesn't await the promise as we want
+    // the task to be executing in the background.
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    scheduler.publishMessages([
+      {
+        name: 'test',
+        items: [
+          // @ts-expect-error missing properties
+          { id: '1', data: {} },
+        ],
+      },
+    ]);
+
+    // Ensure the scheduler is processing the task
+    await waitForChange(() => scheduler.processing);
+
+    // ACT
+    // Attempt to pull the rug from under the executing task
+    // Expected behaviour is awaiting terminate should allow the task to complete
+    await scheduler.terminate();
+
+    // ASSERT
+    expect(testTaskCompleted).equal(true);
+  });
+});

--- a/packages/scheduler-prisma/test/utils/wait_test.ts
+++ b/packages/scheduler-prisma/test/utils/wait_test.ts
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+import { waitForChange, waitTime } from '../../src/utils/wait';
+
+describe('waitx functionality', () => {
+  describe('waitTime', () => {
+    it('should wait for a specified amount of time', async () => {
+      const startTime = Date.now();
+      await waitTime(1000);
+      const endTime = Date.now();
+
+      expect(endTime - startTime).gte(1000);
+    });
+  });
+
+  describe('waitForChange', () => {
+    it('should wait for a condition to change', async () => {
+      const test = true;
+
+      await waitForChange(() => test);
+
+      expect(test).eq(true);
+    });
+
+    it('should timeout without throwing an error', async () => {
+      const test = false;
+
+      await waitForChange(() => test, 100);
+
+      expect(test).eq(false);
+    });
+  });
+});

--- a/packages/scheduler-sequelize/package.json
+++ b/packages/scheduler-sequelize/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "lint": "yarn eslint 'src/**/*.{ts,js}'",
     "build:coverage": "nyc check-coverage --statements 74 --branches 60 --functions 66 --lines 72",
-    "test": "NODE_ENV=test nyc npm run spec",
+    "test": "mocha -r ts-node/register --project tsconfig.test.json test/**/*_test.ts",
     "report": "./node_modules/.bin/nyc report --reporter=html",
     "spec": "mocha",
     "spec:runner": "mocha",

--- a/packages/scheduler-sequelize/package.json
+++ b/packages/scheduler-sequelize/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "lint": "yarn eslint 'src/**/*.{ts,js}'",
     "build:coverage": "nyc check-coverage --statements 74 --branches 60 --functions 66 --lines 72",
-    "test": "mocha -r ts-node/register --project tsconfig.test.json test/**/*_test.ts",
+    "test": "NODE_ENV=test nyc npm run spec",
     "report": "./node_modules/.bin/nyc report --reporter=html",
     "spec": "mocha",
     "spec:runner": "mocha",

--- a/packages/scheduler-sequelize/src/utils/wait.ts
+++ b/packages/scheduler-sequelize/src/utils/wait.ts
@@ -1,0 +1,45 @@
+/**
+ *
+ * @param ms
+ * @returns
+ */
+export function waitTime(ms: number): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/**
+ *
+ * @param fn
+ * @param timeout
+ * @param interval
+ * @returns
+ */
+export function waitForChange(
+  fn: () => boolean,
+  timeout = 5000,
+  interval = 50
+) {
+  return new Promise((resolve, reject) => {
+    const startTime = Date.now();
+
+    const checkCondition = () => {
+      if (fn()) {
+        resolve(true);
+        return;
+      }
+
+      // If timeout has been exceeded, reject with an error.
+      if (Date.now() - startTime > timeout) {
+        reject(new Error('Timeout exceeded while waiting for variable change'));
+        return;
+      }
+
+      // Otherwise, check again after the specified interval.
+      setTimeout(checkCondition, interval);
+    };
+
+    checkCondition();
+  });
+}

--- a/packages/scheduler-sequelize/src/utils/wait.ts
+++ b/packages/scheduler-sequelize/src/utils/wait.ts
@@ -1,7 +1,7 @@
 /**
- *
- * @param ms
- * @returns
+ * Waits for a specified amount of time
+ * @param ms - The amount of time to wait in milliseconds
+ * @returns A promise that resolves after the specified time has elapsed
  */
 export function waitTime(ms: number): Promise<void> {
   return new Promise(resolve => {
@@ -10,11 +10,11 @@ export function waitTime(ms: number): Promise<void> {
 }
 
 /**
- *
- * @param fn
- * @param timeout
- * @param interval
- * @returns
+ * Waits for a condition to change
+ * @param fn - The condition to wait for
+ * @param timeout - The maximum amount of time to wait in milliseconds
+ * @param interval - The interval at which to check the condition in milliseconds
+ * @returns A promise that resolves when the condition changes
  */
 export function waitForChange(
   fn: () => boolean,

--- a/packages/scheduler-sequelize/src/utils/wait.ts
+++ b/packages/scheduler-sequelize/src/utils/wait.ts
@@ -21,7 +21,7 @@ export function waitForChange(
   timeout = 5000,
   interval = 50
 ) {
-  return new Promise((resolve, reject) => {
+  return new Promise(resolve => {
     const startTime = Date.now();
 
     const checkCondition = () => {
@@ -32,7 +32,7 @@ export function waitForChange(
 
       // If timeout has been exceeded, reject with an error.
       if (Date.now() - startTime > timeout) {
-        reject(new Error('Timeout exceeded while waiting for variable change'));
+        resolve(false);
         return;
       }
 

--- a/packages/scheduler-sequelize/test/.eslintrc
+++ b/packages/scheduler-sequelize/test/.eslintrc
@@ -2,9 +2,6 @@
   "extends": [
     "@ordermentum/ordermentum/mocha",
     "@ordermentum/ordermentum/jest"
-  ],
-  "parserOptions": {
-    "project": "../tsconfig.test.json"
-  }
+  ]
 }
 

--- a/packages/scheduler-sequelize/test/fixtures/test_scheduler.fixture.ts
+++ b/packages/scheduler-sequelize/test/fixtures/test_scheduler.fixture.ts
@@ -1,0 +1,26 @@
+import { createLogger } from 'bunyan';
+import { SinonSandbox } from 'sinon';
+import * as models from '../../src/models/index';
+import { JobScheduler, Tasks } from '../../src/index';
+
+/**
+ * Factory that creates a new JobScheduler instance for testing purposes
+ */
+export function createTestScheduler(
+  sandbox: SinonSandbox,
+  props: { tasks: Tasks }
+) {
+  const logger = createLogger({ name: 'test-scheduler' });
+  const initSequelizeStub = sandbox.stub().returns({});
+
+  sandbox.stub(models, 'default').callsFake(initSequelizeStub);
+
+  return new JobScheduler({
+    databaseUri: 'sqlite::memory:',
+    logger,
+    jobsSafeToRestart: [],
+    jobsRiskyToRestart: [],
+    jobsCustomRestart: {},
+    tasks: props.tasks,
+  });
+}

--- a/packages/scheduler-sequelize/test/index_test.ts
+++ b/packages/scheduler-sequelize/test/index_test.ts
@@ -1,0 +1,65 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { createTestScheduler } from './fixtures/test_scheduler.fixture';
+import { waitForChange, waitTime } from '../src/utils/wait';
+
+describe('JobScheduler', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should wait for publish messages when terminated', async () => {
+    // ARRANGE
+
+    // This is the control latch between the task and the outer test.
+    let testTaskCompleted = false;
+
+    const scheduler = createTestScheduler(sandbox, {
+      tasks: {
+        test: async () => {
+          // Wait for the scheduler to start terminating
+          await waitForChange(() => scheduler.exiting);
+
+          // Wait for 100ms to allow the scheduler to terminate without
+          // waiting on this task if it's acting improperly.
+          await waitTime(100);
+
+          // Signal to the outer test that the task has completed
+          testTaskCompleted = true;
+
+          return Promise.resolve();
+        },
+      },
+    });
+
+    // This is intentionally doesn't await the promise as we want
+    // the task to be executing in the background.
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    scheduler.publishMessages([
+      {
+        name: 'test',
+        items: [
+          // @ts-expect-error missing properties
+          { id: '1', data: {} },
+        ],
+      },
+    ]);
+
+    // Ensure the scheduler is processing the task
+    await waitForChange(() => scheduler.processing);
+
+    // ACT
+    // Attempt to pull the rug from under the executing task
+    // Expected behaviour is awaiting terminate should allow the task to complete
+    await scheduler.terminate();
+
+    // ASSERT
+    expect(testTaskCompleted).equal(true);
+  });
+});

--- a/packages/scheduler-sequelize/test/utils/wait_test.ts
+++ b/packages/scheduler-sequelize/test/utils/wait_test.ts
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+import { waitForChange, waitTime } from '../../src/utils/wait';
+
+describe('waitx functionality', () => {
+  describe('waitTime', () => {
+    it('should wait for a specified amount of time', async () => {
+      const startTime = Date.now();
+      await waitTime(1000);
+      const endTime = Date.now();
+
+      expect(endTime - startTime).gte(1000);
+    });
+  });
+
+  describe('waitForChange', () => {
+    it('should wait for a condition to change', async () => {
+      const test = true;
+
+      await waitForChange(() => test);
+
+      expect(test).eq(true);
+    });
+
+    it('should timeout without throwing an error', async () => {
+      const test = false;
+
+      await waitForChange(() => test, 100);
+
+      expect(test).eq(false);
+    });
+  });
+});


### PR DESCRIPTION
#### Description

In a recent incident we determined that pod down scaling was pulling the rug from under executing jobs causing transactions to remain locked ([slack](https://ordermentum.slack.com/archives/C08HYN9AEPQ/p1742280777879989))

----
#### Changes

Added a test condition to invoke the behaviour of tasks being interrupted before completing.

Added wait condition for the processing loop to terminate, [discussion here](https://ordermentum.slack.com/archives/C08HYN9AEPQ/p1742334268581819)

----

#### Testing Instructions
_Outline the steps to test or reproduce the PR._

----

#### Screenshots
_(if appropriate, they help the reviewer visualise the changes)_

----

