### PR TITLE
[DevX-432] Add SQS Health check fifo compatibility

### DIFF
--- a/.changeset/puny-guests-push.md
+++ b/.changeset/puny-guests-push.md
@@ -1,0 +1,5 @@
+---
+"steveo": patch
+---
+
+Support FIFO queues when doing health checks in sqs consumers

--- a/packages/cloudwatch/test/.eslintrc
+++ b/packages/cloudwatch/test/.eslintrc
@@ -4,7 +4,6 @@
     "@ordermentum/ordermentum/jest"
   ],
   "parserOptions": {
-    "project": "../tsconfig.test.json"
+    "project": "./tsconfig.test.json"
   }
 }
-

--- a/packages/datadog/test/.eslintrc
+++ b/packages/datadog/test/.eslintrc
@@ -4,6 +4,6 @@
     "@ordermentum/ordermentum/jest"
   ],
   "parserOptions": {
-    "project": "../tsconfig.test.json"
+    "project": "./tsconfig.test.json"
   }
 }

--- a/packages/newrelic/test/.eslintrc
+++ b/packages/newrelic/test/.eslintrc
@@ -4,6 +4,6 @@
     "@ordermentum/ordermentum/jest"
   ],
   "parserOptions": {
-    "project": "../tsconfig.test.json"
+    "project": "./tsconfig.test.json"
   }
 }

--- a/packages/sentry/test/.eslintrc
+++ b/packages/sentry/test/.eslintrc
@@ -4,6 +4,6 @@
     "@ordermentum/ordermentum/jest"
   ],
   "parserOptions": {
-    "project": "../tsconfig.test.json"
+    "project": "./tsconfig.test.json"
   }
 }

--- a/packages/statsd/test/.eslintrc
+++ b/packages/statsd/test/.eslintrc
@@ -4,6 +4,6 @@
     "@ordermentum/ordermentum/jest"
   ],
   "parserOptions": {
-    "project": "../tsconfig.test.json"
+    "project": "./tsconfig.test.json"
   }
 }

--- a/packages/steveo/src/consumers/sqs.ts
+++ b/packages/steveo/src/consumers/sqs.ts
@@ -284,8 +284,9 @@ class SqsRunner extends BaseRunner implements IRunner {
     if (!item) {
       throw new Error('No queues registered');
     }
+    const topic = this.getTopic(item);
 
-    await this.sqs.getQueueUrl({ QueueName: item });
+    await this.sqs.getQueueUrl({ QueueName: topic });
   };
 
   async getQueueUrl(topic: string) {

--- a/packages/steveo/test/.eslintrc
+++ b/packages/steveo/test/.eslintrc
@@ -4,6 +4,6 @@
     "@ordermentum/ordermentum/jest"
   ],
   "parserOptions": {
-    "project": "../tsconfig.test.json"
+    "project": "./tsconfig.test.json"
   }
 }

--- a/packages/steveo/test/consumer/sqs_test.ts
+++ b/packages/steveo/test/consumer/sqs_test.ts
@@ -503,7 +503,7 @@ describe('runner/sqs', () => {
 
       await runner.healthCheck();
 
-      expect(getQueueUrlStub.calledOnce).to.be.true;
+      expect(getQueueUrlStub.calledOnce).to.equal(true);
       expect(getQueueUrlStub.args[0][0]).to.deep.equal({
         QueueName: 'fifo-health-topic.fifo',
       });
@@ -522,7 +522,7 @@ describe('runner/sqs', () => {
 
       await runner.healthCheck();
 
-      expect(getQueueUrlStub.calledOnce).to.be.true;
+      expect(getQueueUrlStub.calledOnce).to.equal(true);
       expect(getQueueUrlStub.args[0][0]).to.deep.equal({
         QueueName: 'standard-health-topic',
       });

--- a/packages/storage-postgres/test/.eslintrc
+++ b/packages/storage-postgres/test/.eslintrc
@@ -4,7 +4,6 @@
     "@ordermentum/ordermentum/jest"
   ],
   "parserOptions": {
-    "project": "../tsconfig.test.json"
+    "project": "./tsconfig.test.json"
   }
 }
-


### PR DESCRIPTION
This PR adds support for health checking FIFO sqs queues.

Also fixes eslint config across packages to refer to the right tsconfig.json file and refactors sqs consumer test file to have factory methods and use the right types.