### PR TITLE
[CORE-251] Add customisable health check timeouts

### DIFF
--- a/.changeset/forty-colts-hope.md
+++ b/.changeset/forty-colts-hope.md
@@ -1,0 +1,5 @@
+---
+"steveo": minor
+---
+
+Add configurable health check timeout.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
       - name: "Setup Localstack"
         run: |
           pip install localstack==4.14.0 awscli-local[ver1]
-          docker pull localstack/localstack@4.14.0
+          docker pull localstack/localstack:4.14.0
           docker run --name kafka --network=host -d -e KAFKA_NODE_ID=1 -e KAFKA_PROCESS_ROLES=broker,controller -e KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093 -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9092 -e KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT -e KAFKA_CONTROLLER_QUORUM_VOTERS=1@127.0.0.1:9093 -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 -e KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1 -e KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1 -e KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0 -e KAFKA_NUM_PARTITIONS=1 apache/kafka:latest
           localstack start -d
           localstack wait -t 30

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: "Setup Localstack"
         run: |
-          pip install localstack awscli-local[ver1]
+          pip install localstack==4.14.0 awscli-local[ver1]
           docker pull localstack/localstack@4.14.0
           docker run --name kafka --network=host -d -e KAFKA_NODE_ID=1 -e KAFKA_PROCESS_ROLES=broker,controller -e KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093 -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9092 -e KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT -e KAFKA_CONTROLLER_QUORUM_VOTERS=1@127.0.0.1:9093 -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 -e KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1 -e KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1 -e KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0 -e KAFKA_NUM_PARTITIONS=1 apache/kafka:latest
           localstack start -d

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
       - name: "Setup Localstack"
         run: |
           pip install localstack awscli-local[ver1]
-          docker pull localstack/localstack
+          docker pull localstack/localstack@4.14.0
           docker run --name kafka --network=host -d -e KAFKA_NODE_ID=1 -e KAFKA_PROCESS_ROLES=broker,controller -e KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093 -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9092 -e KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT -e KAFKA_CONTROLLER_QUORUM_VOTERS=1@127.0.0.1:9093 -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 -e KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1 -e KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1 -e KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0 -e KAFKA_NUM_PARTITIONS=1 apache/kafka:latest
           localstack start -d
           localstack wait -t 30

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: "Setup Localstack"
         run: |
+          export IMAGE_NAME=localstack/localstack:4.14.0
           pip install localstack==4.14.0 awscli-local[ver1]
           docker pull localstack/localstack:4.14.0
           docker run --name kafka --network=host -d -e KAFKA_NODE_ID=1 -e KAFKA_PROCESS_ROLES=broker,controller -e KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093 -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9092 -e KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT -e KAFKA_CONTROLLER_QUORUM_VOTERS=1@127.0.0.1:9093 -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 -e KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1 -e KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1 -e KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0 -e KAFKA_NUM_PARTITIONS=1 apache/kafka:latest

--- a/packages/steveo/src/common.ts
+++ b/packages/steveo/src/common.ts
@@ -197,6 +197,11 @@ export interface Configuration {
    */
   tasksPath?: string;
   middleware?: Middleware[];
+  /**
+   * @description Timeout in milliseconds for health check calls.
+   * Kafka default: 1000ms. SQS default: no timeout.
+   */
+  healthCheckTimeout?: number;
 }
 
 export type Pool<T> = GenericPool<T>;

--- a/packages/steveo/src/config.ts
+++ b/packages/steveo/src/config.ts
@@ -34,6 +34,7 @@ export const getConfig = (config: Configuration) => {
   parameters.middleware = config.middleware ?? [];
   parameters.terminationWaitCount = config.terminationWaitCount ?? 180;
   parameters.tasksPath = config.tasksPath;
+  parameters.healthCheckTimeout = config.healthCheckTimeout;
 
   if (parameters.engine === 'kafka') {
     const kafkaConfig = config as KafkaConfiguration;

--- a/packages/steveo/src/consumers/kafka.ts
+++ b/packages/steveo/src/consumers/kafka.ts
@@ -290,7 +290,7 @@ class KafkaRunner
         {
           allTopics: false,
           topic: '',
-          timeout: 1000,
+          timeout: this.config.healthCheckTimeout ?? 1000,
         },
         (err: Error, meta) => {
           this.logger.debug(`metadata response meta=${meta} err=${err}`);

--- a/packages/steveo/src/consumers/sqs.ts
+++ b/packages/steveo/src/consumers/sqs.ts
@@ -299,7 +299,7 @@ class SqsRunner extends BaseRunner implements IRunner {
 
     if (this.config.healthCheckTimeout != null) {
       let timerId: ReturnType<typeof setTimeout>;
-      const timeout = new Promise<never>((_, reject) => {
+      const timeout = new Promise<never>((_resolve, reject) => {
         timerId = setTimeout(
           () => reject(new Error('SQS health check timed out')),
           this.config.healthCheckTimeout

--- a/packages/steveo/src/consumers/sqs.ts
+++ b/packages/steveo/src/consumers/sqs.ts
@@ -295,7 +295,24 @@ class SqsRunner extends BaseRunner implements IRunner {
     }
     const topic = this.getTopic(item);
 
-    await this.sqs.getQueueUrl({ QueueName: topic });
+    const check = this.sqs.getQueueUrl({ QueueName: topic });
+
+    if (this.config.healthCheckTimeout != null) {
+      let timerId: ReturnType<typeof setTimeout>;
+      const timeout = new Promise<never>((_, reject) => {
+        timerId = setTimeout(
+          () => reject(new Error('SQS health check timed out')),
+          this.config.healthCheckTimeout
+        );
+      });
+      try {
+        await Promise.race([check, timeout]);
+      } finally {
+        clearTimeout(timerId!);
+      }
+    } else {
+      await check;
+    }
   };
 
   async getQueueUrl(topic: string) {

--- a/packages/steveo/test/common/config_test.ts
+++ b/packages/steveo/test/common/config_test.ts
@@ -164,4 +164,23 @@ describe('Config', () => {
       expect(config.consumer).to.be.undefined;
     });
   });
+
+  describe('healthCheckTimeout', () => {
+    it('passes through healthCheckTimeout when provided', () => {
+      const config = Config({
+        engine: 'kafka',
+        bootstrapServers: 'kafka://kafka:9200',
+        healthCheckTimeout: 5000,
+      });
+      expect(config.healthCheckTimeout).to.equal(5000);
+    });
+
+    it('does not set healthCheckTimeout when not provided', () => {
+      const config = Config({
+        engine: 'kafka',
+        bootstrapServers: 'kafka://kafka:9200',
+      });
+      expect(config.healthCheckTimeout).to.be.undefined;
+    });
+  });
 });

--- a/packages/steveo/test/consumer/kafka_test.ts
+++ b/packages/steveo/test/consumer/kafka_test.ts
@@ -533,4 +533,39 @@ describe('runner/kafka', () => {
     // Max concurrent should not exceed limit of 3
     expect(maxConcurrentSeen).to.be.at.most(3);
   });
+
+  describe('healthCheck', () => {
+    it('should use default 1000ms timeout when healthCheckTimeout is not configured', async () => {
+      const getMetadataStub = sandbox
+        .stub(runner.consumer, 'getMetadata')
+        .callsArgWith(1, null, {});
+
+      await runner.healthCheck();
+
+      expect(getMetadataStub.calledOnce).to.equal(true);
+      expect(getMetadataStub.args[0][0].timeout).to.equal(1000);
+    });
+
+    it('should use configured healthCheckTimeout', async () => {
+      const steveo = {
+        config: {
+          bootstrapServers: 'kafka:9200',
+          engine: 'kafka',
+          securityProtocol: 'plaintext',
+          healthCheckTimeout: 5000,
+        },
+        registry,
+      };
+      // @ts-ignore
+      const customRunner = new Runner(steveo);
+      const getMetadataStub = sandbox
+        .stub(customRunner.consumer, 'getMetadata')
+        .callsArgWith(1, null, {});
+
+      await customRunner.healthCheck();
+
+      expect(getMetadataStub.calledOnce).to.equal(true);
+      expect(getMetadataStub.args[0][0].timeout).to.equal(5000);
+    });
+  });
 });

--- a/packages/steveo/test/consumer/sqs_test.ts
+++ b/packages/steveo/test/consumer/sqs_test.ts
@@ -541,6 +541,65 @@ describe('runner/sqs', () => {
         expect((err as Error).message).to.equal('No queues registered');
       }
     });
+
+    it('should not apply a timeout when healthCheckTimeout is not configured', async () => {
+      const registry = createMockRegistry(sandbox);
+      registry.getTopics = sandbox.stub().returns(['health-topic']);
+      const steveo = createSteveoInstance(registry);
+      const runner = new Runner(steveo);
+
+      // getQueueUrl resolves after 50ms — should still succeed with no timeout
+      const getQueueUrlStub = sandbox
+        .stub(runner.sqs, 'getQueueUrl')
+        .callsFake(() => new Promise(resolve => setTimeout(() => resolve({}), 50)));
+
+      await runner.healthCheck();
+
+      expect(getQueueUrlStub.calledOnce).to.equal(true);
+    });
+
+    it('should reject when healthCheckTimeout is exceeded', async () => {
+      const config: SQSConfiguration = {
+        ...createSQSConfig(),
+        healthCheckTimeout: 10,
+      };
+      const registry = createMockRegistry(sandbox);
+      registry.getTopics = sandbox.stub().returns(['health-topic']);
+      const steveo = createSteveoInstance(registry, config);
+      const runner = new Runner(steveo);
+
+      // getQueueUrl takes 200ms — longer than the 10ms timeout
+      sandbox
+        .stub(runner.sqs, 'getQueueUrl')
+        .callsFake(() => new Promise(resolve => setTimeout(() => resolve({}), 200)));
+
+      try {
+        await runner.healthCheck();
+        expect.fail('Expected an error to be thrown');
+      } catch (err) {
+        expect(err).to.be.instanceOf(Error);
+        expect((err as Error).message).to.equal('SQS health check timed out');
+      }
+    });
+
+    it('should succeed when healthCheckTimeout is configured and not exceeded', async () => {
+      const config: SQSConfiguration = {
+        ...createSQSConfig(),
+        healthCheckTimeout: 5000,
+      };
+      const registry = createMockRegistry(sandbox);
+      registry.getTopics = sandbox.stub().returns(['health-topic']);
+      const steveo = createSteveoInstance(registry, config);
+      const runner = new Runner(steveo);
+
+      const getQueueUrlStub = sandbox
+        .stub(runner.sqs, 'getQueueUrl')
+        .resolves({});
+
+      await runner.healthCheck();
+
+      expect(getQueueUrlStub.calledOnce).to.equal(true);
+    });
   });
 
   it('calculates duration of a task run correctly', async () => {


### PR DESCRIPTION
#### Description

Adds an optional `healthCheckTimeout` to the Steveo configuration to allow manual configuration of the healthcheck timeout. The change is backwards compatible with old defaults in use if the configuration is now applied.

A recurring issue in production revolves around the timeout of the `getMetadata` call. Whilst Warpstream does not provide direct guidance on their documentation on individual request timeouts. Indications indicate that 5-15s responses may be expected in certain worst-case circumstances. This change is the first step in validating some more appropriate values for this Steveo CDC usage using Warpstream.

This also hardcodes a series of Localstack CLI/Docker changes to ensure continued operation for Steveo CI usage despite a series of breaking changes in recent Localstack versions. 

