### PR TITLE
Pin npm to 11.10.0 to work around nodejs #62463

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: 22.x
 
       - name: Install latest npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.10.0
 
       - name: Configure npm for install
         run: |


### PR DESCRIPTION
## Description

Pins npm to 11.10.0 in the release workflow to work around a Node.js v22.22.2 bug that breaks `npm install -g npm@latest`.

## Problem

Node.js v22.22.2 introduced a regression ([nodejs/node#62430](https://github.com/nodejs/node/issues/62430)) where running `npm i -g npm@latest` fails with:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
```

This breaks our CI release workflow, which uses `npm install -g npm@latest` to ensure the latest npm is available before publishing.

## Changes

- Pin `npm install -g npm@latest` to `npm install -g npm@11.10.0` in `.github/workflows/release.yml` (the last known working version)

## Notes

This pin can be reverted once the upstream Node.js issue is resolved.