### PR TITLE
Add Node 22 and Node 24 tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
           - 5432:5432
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
#### Description

Enables CI testing for Node 22 and Node 24 as these are now in common use. 

