### PR TITLE
Change Kafka health check to simple connectivity check

### DIFF
--- a/.changeset/quick-years-cry.md
+++ b/.changeset/quick-years-cry.md
@@ -1,0 +1,5 @@
+---
+"steveo": major
+---
+
+Change Kafka health check to simple connectivity check

--- a/packages/steveo/src/consumers/kafka.ts
+++ b/packages/steveo/src/consumers/kafka.ts
@@ -282,9 +282,10 @@ class KafkaRunner
   healthCheck = async function () {
     return new Promise<void>((resolve, reject) => {
       if (this.consumer.isConnected()) {
-        return resolve();
+        resolve();
+        return;
       }
-      return reject(new Error('Kafka consumer is not connected'));
+      reject(new Error('Kafka consumer is not connected'));
     });
   };
 

--- a/packages/steveo/src/consumers/kafka.ts
+++ b/packages/steveo/src/consumers/kafka.ts
@@ -281,25 +281,10 @@ class KafkaRunner
    */
   healthCheck = async function () {
     return new Promise<void>((resolve, reject) => {
-      /**
-       * if you are concerned about potential performance issues,
-       * don't be, it returns early if it has a local connection status
-       * only falls back to the kafka client if the local connection status is missing
-       */
-      this.consumer.getMetadata(
-        {
-          allTopics: false,
-          topic: '',
-          timeout: this.config.healthCheckTimeout ?? 1000,
-        },
-        (err: Error, meta) => {
-          this.logger.debug(`metadata response meta=${meta} err=${err}`);
-          if (err) {
-            return reject(err);
-          }
-          return resolve(meta);
-        }
-      );
+      if (this.consumer.isConnected()) {
+        return resolve();
+      }
+      return reject(new Error('Kafka consumer is not connected'));
     });
   };
 

--- a/packages/steveo/test/consumer/kafka_test.ts
+++ b/packages/steveo/test/consumer/kafka_test.ts
@@ -535,37 +535,28 @@ describe('runner/kafka', () => {
   });
 
   describe('healthCheck', () => {
-    it('should use default 1000ms timeout when healthCheckTimeout is not configured', async () => {
-      const getMetadataStub = sandbox
-        .stub(runner.consumer, 'getMetadata')
-        .callsArgWith(1, null, {});
+    it('should resolve when consumer is connected', async () => {
+      const isConnectedStub = sandbox
+        .stub(runner.consumer, 'isConnected')
+        .returns(true);
 
       await runner.healthCheck();
 
-      expect(getMetadataStub.calledOnce).to.equal(true);
-      expect(getMetadataStub.args[0][0].timeout).to.equal(1000);
+      expect(isConnectedStub.calledOnce).to.equal(true);
     });
 
-    it('should use configured healthCheckTimeout', async () => {
-      const steveo = {
-        config: {
-          bootstrapServers: 'kafka:9200',
-          engine: 'kafka',
-          securityProtocol: 'plaintext',
-          healthCheckTimeout: 5000,
-        },
-        registry,
-      };
-      // @ts-ignore
-      const customRunner = new Runner(steveo);
-      const getMetadataStub = sandbox
-        .stub(customRunner.consumer, 'getMetadata')
-        .callsArgWith(1, null, {});
+    it('should reject when consumer is not connected', async () => {
+      sandbox.stub(runner.consumer, 'isConnected').returns(false);
 
-      await customRunner.healthCheck();
+      let error: Error | undefined;
+      try {
+        await runner.healthCheck();
+      } catch (e) {
+        error = e as Error;
+      }
 
-      expect(getMetadataStub.calledOnce).to.equal(true);
-      expect(getMetadataStub.args[0][0].timeout).to.equal(5000);
+      expect(error).to.be.an.instanceOf(Error);
+      expect(error?.message).to.equal('Kafka consumer is not connected');
     });
   });
 });


### PR DESCRIPTION
#### Description

Following ongoing testing it was determined the optimal test for Kafka connectivity is relying on the `@confluentinc/kafka-javascript` library's internal tracking. This state is stored inside the library based on event feeds and can be simply retrieved synchronously and requires no off-service calls. 

Because this change may break the expectations of some implementations, it has been made as a breaking change, but there are no functional changes to the API. 

