### PR TITLE
[HOTFIX] Improve error logging on Kafka connection errors

### DIFF
--- a/.changeset/fresh-pears-clap.md
+++ b/.changeset/fresh-pears-clap.md
@@ -1,0 +1,5 @@
+---
+"steveo": minor
+---
+
+Added errors to connection rejection

--- a/packages/steveo/src/consumers/kafka.ts
+++ b/packages/steveo/src/consumers/kafka.ts
@@ -330,15 +330,18 @@ class KafkaRunner
   process(topics: Array<string>) {
     return new Promise<KafkaConsumer>((resolve, reject) => {
       const timeoutId = setTimeout(() => {
-        this.logger.error('Connection timed out');
-        reject();
+        this.logger.error(
+          'Kafka connection timed out. Bootstrap servers:',
+          this.config.bootstrapServers
+        );
+        reject(new Error('Kafka connection timed out'));
       }, this.config.connectionTimeout);
 
       this.consumer.connect({}, err => {
         clearTimeout(timeoutId);
         if (err) {
           this.logger.error('Error initializing consumer', err);
-          reject();
+          reject(err);
         }
       });
 

--- a/packages/steveo/test/consumer/kafka_test.ts
+++ b/packages/steveo/test/consumer/kafka_test.ts
@@ -534,6 +534,61 @@ describe('runner/kafka', () => {
     expect(maxConcurrentSeen).to.be.at.most(3);
   });
 
+  describe('process', () => {
+    it('should reject with an Error when the connection times out', async () => {
+      // Arrange: connect never invokes its callback, so only the timeout path fires
+      sandbox.stub(runner.consumer, 'connect');
+      sandbox.stub(runner.consumer, 'on');
+
+      // Act
+      const promise = runner.process(['test-topic']);
+      const caught = promise.catch((e: unknown) => e);
+      await clock.tickAsync(5000);
+      const error = (await caught) as Error;
+
+      // Assert: rejection carries an Error (not undefined) so Node won't crash
+      // with an unhandled rejection that has no stack.
+      expect(error).to.be.an.instanceOf(Error);
+      expect(error.message).to.equal('Kafka connection timed out');
+    });
+
+    it('should log bootstrap servers when the connection times out', async () => {
+      const errorSpy = sandbox.spy(runner.logger, 'error');
+      sandbox.stub(runner.consumer, 'connect');
+      sandbox.stub(runner.consumer, 'on');
+
+      const promise = runner.process(['test-topic']);
+      const caught = promise.catch(() => undefined);
+      await clock.tickAsync(5000);
+      await caught;
+
+      sinon.assert.calledWith(
+        errorSpy,
+        'Kafka connection timed out. Bootstrap servers:',
+        'kafka:9200'
+      );
+    });
+
+    it('should reject with the underlying error when consumer.connect fails', async () => {
+      const connectError = new Error('Broker not available');
+      sandbox
+        .stub(runner.consumer, 'connect')
+        .callsArgWith(1, connectError);
+      sandbox.stub(runner.consumer, 'on');
+
+      let caught: unknown;
+      try {
+        await runner.process(['test-topic']);
+      } catch (e) {
+        caught = e;
+      }
+
+      // The original error object must be preserved so callers can inspect
+      // `.message` / `.code` / stack rather than receive `undefined`.
+      expect(caught).to.equal(connectError);
+    });
+  });
+
   describe('healthCheck', () => {
     it('should resolve when consumer is connected', async () => {
       const isConnectedStub = sandbox


### PR DESCRIPTION
#### Description

Follow up from SANDBOX INC-1529, this PR adds useful rejection errors to the Kafka connection path + validation errors for that path. 



