### PR TITLE
Commit every Kafka partition a batch touched, and flush before revoke

### DIFF
--- a/.changeset/spotty-donkeys-drum.md
+++ b/.changeset/spotty-donkeys-drum.md
@@ -1,0 +1,11 @@
+---
+"steveo": minor
+---
+
+Stop Kafka consumers redelivering messages after a batch or a rebalance
+
+A batch is drained from the consumer queue, so it can span partitions and topics, but only the last message in it was committed. Every partition a batch drew from is now committed at its highest processed offset.
+
+Partition assignment is now handled by the client rather than a callback in steveo. Cooperative rebalancing works properly (the callback did a full assign/unassign, dropping partitions the member still owned), and a failed rebalance no longer shuts the consumer down. Before revoked partitions are released, steveo commits the offsets it has processed — librdkafka only flushes on revoke when `enable.auto.commit` is on, which steveo turns off.
+
+Anything passing its own `rebalance_cb` through `consumer.global` still overrides the client's handling; the offset flush runs either way.

--- a/packages/steveo/src/consumers/kafka.ts
+++ b/packages/steveo/src/consumers/kafka.ts
@@ -3,6 +3,7 @@ import Kafka, {
   IAdminClient,
   KafkaConsumer,
   Message,
+  TopicPartitionOffset,
 } from '@confluentinc/kafka-javascript';
 import Bluebird from 'bluebird';
 import nullLogger from 'null-logger';
@@ -31,6 +32,8 @@ class KafkaRunner
 
   private debugEnabled: boolean;
 
+  private processedOffsets = new Map<string, TopicPartitionOffset>();
+
   constructor(steveo: Steveo) {
     super(steveo);
     this.config = steveo.config as KafkaConfiguration;
@@ -47,36 +50,8 @@ class KafkaRunner
       {
         'bootstrap.servers': this.config.bootstrapServers,
         'security.protocol': this.config.securityProtocol,
-        rebalance_cb: (err, assignment) => {
-          this.logger.debug('Rebalance event', err, assignment);
-          try {
-            /**
-             * These error codes can mean that the consumer needs to reassign
-             *
-             * KafkaJS (another kafka client) has a similar implementation
-             * See: https://github.com/tulios/kafkajs/pull/1474
-             * See: https://github.com/tulios/kafkajs/blob/master/src/consumer/runner.js#L115-L160
-             */
-            if (
-              [
-                Kafka.CODES.ERRORS.ERR__ASSIGN_PARTITIONS,
-                Kafka.CODES.ERRORS.ERR_NOT_COORDINATOR_FOR_GROUP,
-                Kafka.CODES.ERRORS.ERR_REBALANCE_IN_PROGRESS,
-                Kafka.CODES.ERRORS.ERR_ILLEGAL_GENERATION,
-                Kafka.CODES.ERRORS.ERR_UNKNOWN_MEMBER_ID,
-              ].includes(err.code)
-            ) {
-              //
-              this.consumer.assign(assignment);
-            } else if (err.code === Kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS) {
-              this.consumer.unassign();
-            }
-          } catch (e) {
-            this.logger.error('Error during rebalance', e);
-            // Shutting down the consumer to not have a zombie consumer
-            if (this.consumer.isConnected()) this.shutdown();
-          }
-        },
+        // the client handles assign/unassign, including cooperative
+        rebalance_cb: true,
         offset_commit_cb: (err, topicPartitions) => {
           if (err) {
             this.logger.error(err);
@@ -99,6 +74,16 @@ class KafkaRunner
       },
       this.config.consumer?.topic ?? {}
     );
+
+    this.consumer.on('rebalance', err => {
+      if (err?.code === Kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS) {
+        this.flushOffsets();
+      }
+    });
+
+    this.consumer.on('rebalance.error', err => {
+      this.logger.error('Error during rebalance', err);
+    });
 
     this.adminClient = AdminClient.create({
       'bootstrap.servers': this.config.bootstrapServers,
@@ -230,8 +215,6 @@ class KafkaRunner
 
     // Always commit, even if there are failures
     // This prevents infinite reprocessing of failed messages
-    const lastMessage = batch[batch.length - 1];
-
     if (failures.length > 0) {
       this.logger.warn(
         `Batch had ${failures.length} failures out of ${batch.length} messages.`
@@ -250,13 +233,57 @@ class KafkaRunner
         error: failures[0],
       });
     } else {
-      this.logger.debug(
-        `Batch succeeded (${batch.length} messages), committing offset ${lastMessage.offset}`
-      );
+      this.logger.debug(`Batch succeeded (${batch.length} messages)`);
     }
 
-    // Always commit the last offset to move forward
-    this.consumer.commitMessage(lastMessage);
+    this.commitBatch(batch);
+  }
+
+  /**
+   * A batch is drained from the consumer queue, so it can span partitions and
+   * topics. Committing only the final message leaves the rest of the batch
+   * uncommitted and redelivered on the next rebalance.
+   */
+  private commitBatch(batch: Message[]): void {
+    const highestPerPartition = new Map<string, Message>();
+
+    for (const message of batch) {
+      const key = `${message.topic}/${message.partition}`;
+      const highest = highestPerPartition.get(key);
+
+      if (!highest || message.offset > highest.offset) {
+        highestPerPartition.set(key, message);
+      }
+    }
+
+    for (const [key, message] of highestPerPartition) {
+      this.consumer.commitMessage(message);
+      this.processedOffsets.set(key, {
+        topic: message.topic,
+        partition: message.partition,
+        offset: message.offset + 1,
+      });
+    }
+  }
+
+  /**
+   * commitMessage is queued, and librdkafka only flushes offsets on revoke when
+   * enable.auto.commit is on. Committing here, while the old generation is
+   * still current, keeps those messages from being redelivered. We send what we
+   * processed rather than the stored offsets, which run ahead of processing.
+   */
+  private flushOffsets(): void {
+    if (!this.processedOffsets.size) {
+      return;
+    }
+
+    try {
+      this.consumer.commitSync([...this.processedOffsets.values()]);
+    } catch (e) {
+      this.logger.error('Error committing offsets before revoke', e);
+    }
+
+    this.processedOffsets.clear();
   }
 
   reconnect = async () =>

--- a/packages/steveo/test/consumer/kafka_batch_commit_test.ts
+++ b/packages/steveo/test/consumer/kafka_batch_commit_test.ts
@@ -1,0 +1,111 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import Runner from '../../src/consumers/kafka';
+import { build } from '../../src/lib/pool';
+
+const buildRunner = (sandbox, batchSize = 10) => {
+  const subscribeStub = sinon.stub().resolves({ some: 'success' });
+  const registry = {
+    getTask: () => ({
+      publish: () => {},
+      subscribe: subscribeStub,
+    }),
+    emit: sandbox.stub(),
+    events: { emit: sandbox.stub() },
+  };
+  const steveo = {
+    config: {
+      bootstrapServers: 'kafka:9200',
+      engine: 'kafka',
+      securityProtocol: 'plaintext',
+      batchProcessing: { enabled: true, batchSize },
+    },
+    registry,
+    // @ts-expect-error
+    pool: build(registry),
+  };
+  // @ts-expect-error
+  const runner: any = new Runner(steveo);
+  return { runner, subscribeStub };
+};
+
+const message = (topic: string, partition: number, offset: number) => ({
+  value: Buffer.from(JSON.stringify({ topic, partition, offset })),
+  topic,
+  partition,
+  offset,
+});
+
+const committed = (commitStub: sinon.SinonStub) =>
+  commitStub
+    .getCalls()
+    .map(call => call.args[0])
+    .map(({ topic, partition, offset }) => `${topic}/${partition}/${offset}`)
+    .sort();
+
+describe('runner/kafka - batch commit coverage', () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('commits the highest processed offset for every partition in the batch', async () => {
+    const { runner, subscribeStub } = buildRunner(sandbox);
+    const commitStub = sandbox.stub(runner.consumer, 'commitMessage');
+
+    await runner.processBatch([
+      message('test-topic', 0, 100),
+      message('test-topic', 1, 200),
+      message('test-topic', 0, 101),
+      message('test-topic', 1, 201),
+    ]);
+
+    expect(subscribeStub.callCount).to.equal(4);
+    expect(committed(commitStub)).to.eqls([
+      'test-topic/0/101',
+      'test-topic/1/201',
+    ]);
+  });
+
+  it('commits every topic when a batch spans multiple subscribed topics', async () => {
+    const { runner } = buildRunner(sandbox);
+    const commitStub = sandbox.stub(runner.consumer, 'commitMessage');
+
+    await runner.processBatch([
+      message('topic-a', 0, 10),
+      message('topic-b', 0, 20),
+    ]);
+
+    expect(committed(commitStub)).to.eqls(['topic-a/0/10', 'topic-b/0/20']);
+  });
+
+  it('commits the highest offset even when the batch arrives out of order', async () => {
+    const { runner } = buildRunner(sandbox);
+    const commitStub = sandbox.stub(runner.consumer, 'commitMessage');
+
+    await runner.processBatch([
+      message('test-topic', 4, 702),
+      message('test-topic', 4, 700),
+      message('test-topic', 4, 701),
+    ]);
+
+    expect(committed(commitStub)).to.eqls(['test-topic/4/702']);
+  });
+
+  it('commits a single partition batch exactly once', async () => {
+    const { runner } = buildRunner(sandbox);
+    const commitStub = sandbox.stub(runner.consumer, 'commitMessage');
+
+    await runner.processBatch([
+      message('test-topic', 3, 500),
+      message('test-topic', 3, 501),
+    ]);
+
+    expect(committed(commitStub)).to.eqls(['test-topic/3/501']);
+  });
+});

--- a/packages/steveo/test/consumer/kafka_batch_commit_test.ts
+++ b/packages/steveo/test/consumer/kafka_batch_commit_test.ts
@@ -1,13 +1,20 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
+import { KafkaConsumer } from '@confluentinc/kafka-javascript';
 import Runner from '../../src/consumers/kafka';
 import { build } from '../../src/lib/pool';
+
+// the runner's own type hides processBatch, which these tests drive directly
+type TestRunner = {
+  processBatch(messages: unknown[]): Promise<void>;
+  consumer: KafkaConsumer;
+};
 
 const buildRunner = (sandbox, batchSize = 10) => {
   const subscribeStub = sinon.stub().resolves({ some: 'success' });
   const registry = {
     getTask: () => ({
-      publish: () => {},
+      publish: sinon.stub(),
       subscribe: subscribeStub,
     }),
     emit: sandbox.stub(),
@@ -21,11 +28,11 @@ const buildRunner = (sandbox, batchSize = 10) => {
       batchProcessing: { enabled: true, batchSize },
     },
     registry,
-    // @ts-expect-error
+    // @ts-expect-error registry double only carries what the pool reads
     pool: build(registry),
   };
-  // @ts-expect-error
-  const runner: any = new Runner(steveo);
+  // @ts-expect-error steveo double only carries what the runner reads
+  const runner = new Runner(steveo) as unknown as TestRunner;
   return { runner, subscribeStub };
 };
 

--- a/packages/steveo/test/consumer/kafka_rebalance_test.ts
+++ b/packages/steveo/test/consumer/kafka_rebalance_test.ts
@@ -1,0 +1,206 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import Kafka from '@confluentinc/kafka-javascript';
+import Runner from '../../src/consumers/kafka';
+import { build } from '../../src/lib/pool';
+
+const { ERR__REVOKE_PARTITIONS, ERR__ASSIGN_PARTITIONS } = Kafka.CODES.ERRORS;
+
+const TOPIC = 'test-topic';
+
+const buildRunner = (sandbox: sinon.SinonSandbox, protocol = 'EAGER') => {
+  const registry = {
+    getTask: () => ({ publish: () => {}, subscribe: sinon.stub().resolves() }),
+    emit: sandbox.stub(),
+    events: { emit: sandbox.stub() },
+  };
+  const steveo = {
+    config: {
+      bootstrapServers: 'kafka:9200',
+      engine: 'kafka',
+      securityProtocol: 'plaintext',
+      batchProcessing: { enabled: true, batchSize: 10 },
+    },
+    registry,
+    // @ts-expect-error
+    pool: build(registry),
+  };
+  // @ts-expect-error
+  const runner: any = new Runner(steveo);
+  sandbox.stub(runner.consumer, 'rebalanceProtocol').returns(protocol);
+  sandbox.stub(runner.consumer, 'commitMessage');
+  return runner;
+};
+
+const message = (partition: number, offset: number) => ({
+  value: Buffer.from(JSON.stringify({ partition, offset })),
+  topic: TOPIC,
+  partition,
+  offset,
+});
+
+// driving globalConfig runs the client's own rebalance handling, so these
+// assertions cover our listener and the client's assign/unassign together
+const rebalance = (runner, code: number, assignment: unknown[] = []) =>
+  runner.consumer.globalConfig.rebalance_cb(code, assignment);
+
+describe('runner/kafka - rebalance', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('eager protocol', () => {
+    it('lets the client assign the partitions it was given', () => {
+      const runner = buildRunner(sandbox);
+      const assign = sandbox.stub(runner.consumer, 'assign');
+
+      rebalance(runner, ERR__ASSIGN_PARTITIONS, [
+        { topic: TOPIC, partition: 0 },
+      ]);
+
+      expect(assign.calledOnce, 'client did not assign').to.equal(true);
+      expect(assign.firstCall.args[0]).to.eqls([
+        { topic: TOPIC, partition: 0 },
+      ]);
+    });
+
+    it('does not commit when partitions are assigned', () => {
+      const runner = buildRunner(sandbox);
+      const commitSync = sandbox.stub(runner.consumer, 'commitSync');
+      sandbox.stub(runner.consumer, 'assign');
+
+      rebalance(runner, ERR__ASSIGN_PARTITIONS, [
+        { topic: TOPIC, partition: 0 },
+      ]);
+
+      expect(commitSync.called, 'assign must not commit').to.equal(false);
+    });
+  });
+
+  describe('revoke', () => {
+    it('flushes the offsets it processed before the client releases the partitions', async () => {
+      const runner = buildRunner(sandbox);
+      const commitSync = sandbox.stub(runner.consumer, 'commitSync');
+      const unassign = sandbox.stub(runner.consumer, 'unassign');
+
+      await runner.processBatch([
+        message(0, 100),
+        message(1, 200),
+        message(0, 101),
+      ]);
+
+      rebalance(runner, ERR__REVOKE_PARTITIONS);
+
+      expect(commitSync.calledOnce, 'commitSync was never called').to.equal(
+        true
+      );
+      expect(commitSync.firstCall.args[0]).to.eqls([
+        { topic: TOPIC, partition: 0, offset: 102 },
+        { topic: TOPIC, partition: 1, offset: 201 },
+      ]);
+      expect(
+        commitSync.calledBefore(unassign),
+        'offsets must be flushed before the partitions are released'
+      ).to.equal(true);
+    });
+
+    it('does not commit anything it has not processed', () => {
+      const runner = buildRunner(sandbox);
+      const commitSync = sandbox.stub(runner.consumer, 'commitSync');
+      const unassign = sandbox.stub(runner.consumer, 'unassign');
+
+      rebalance(runner, ERR__REVOKE_PARTITIONS);
+
+      expect(
+        commitSync.called,
+        'nothing was processed, so there is nothing to flush'
+      ).to.equal(false);
+      expect(unassign.called, 'client did not unassign').to.equal(true);
+    });
+
+    it('releases the partitions even when the flush fails', async () => {
+      const runner = buildRunner(sandbox);
+      sandbox
+        .stub(runner.consumer, 'commitSync')
+        .throws(new Error('Broker: Unknown member'));
+      const unassign = sandbox.stub(runner.consumer, 'unassign');
+
+      await runner.processBatch([message(0, 100)]);
+      rebalance(runner, ERR__REVOKE_PARTITIONS);
+
+      expect(unassign.called, 'unassign was skipped').to.equal(true);
+    });
+  });
+
+  describe('cooperative protocol', () => {
+    it('adds only the newly granted partitions', () => {
+      const runner = buildRunner(sandbox, 'COOPERATIVE');
+      const incrementalAssign = sandbox.stub(
+        runner.consumer,
+        'incrementalAssign'
+      );
+      const assign = sandbox.stub(runner.consumer, 'assign');
+
+      rebalance(runner, ERR__ASSIGN_PARTITIONS, [
+        { topic: TOPIC, partition: 0 },
+      ]);
+
+      expect(
+        incrementalAssign.calledOnce,
+        'cooperative assign must be incremental'
+      ).to.equal(true);
+      expect(
+        assign.called,
+        'a full assign drops partitions the member still owns'
+      ).to.equal(false);
+    });
+
+    it('releases only the revoked partitions, after flushing', async () => {
+      const runner = buildRunner(sandbox, 'COOPERATIVE');
+      const commitSync = sandbox.stub(runner.consumer, 'commitSync');
+      const incrementalUnassign = sandbox.stub(
+        runner.consumer,
+        'incrementalUnassign'
+      );
+      const unassign = sandbox.stub(runner.consumer, 'unassign');
+
+      await runner.processBatch([message(0, 100)]);
+      rebalance(runner, ERR__REVOKE_PARTITIONS, [
+        { topic: TOPIC, partition: 0 },
+      ]);
+
+      expect(
+        incrementalUnassign.calledOnce,
+        'cooperative revoke must be incremental'
+      ).to.equal(true);
+      expect(
+        unassign.called,
+        'a full unassign drops partitions that were not revoked'
+      ).to.equal(false);
+      expect(
+        commitSync.calledBefore(incrementalUnassign),
+        'offsets must be flushed before the partitions are released'
+      ).to.equal(true);
+    });
+  });
+
+  it('keeps the consumer alive when the rebalance itself fails', () => {
+    const runner = buildRunner(sandbox);
+    sandbox.stub(runner.consumer, 'assign').throws(new Error('assign failed'));
+    sandbox.stub(runner.consumer, 'isConnected').returns(true);
+    const shutdown = sandbox.stub(runner, 'shutdown');
+
+    rebalance(runner, ERR__ASSIGN_PARTITIONS, [{ topic: TOPIC, partition: 0 }]);
+
+    expect(
+      shutdown.called,
+      'a failed rebalance must not tear the consumer down'
+    ).to.equal(false);
+  });
+});

--- a/packages/steveo/test/consumer/kafka_rebalance_test.ts
+++ b/packages/steveo/test/consumer/kafka_rebalance_test.ts
@@ -1,8 +1,20 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import Kafka from '@confluentinc/kafka-javascript';
+import Kafka, { KafkaConsumer } from '@confluentinc/kafka-javascript';
 import Runner from '../../src/consumers/kafka';
 import { build } from '../../src/lib/pool';
+
+// the runner's own type hides processBatch, and globalConfig is untyped
+type TestRunner = {
+  processBatch(messages: unknown[]): Promise<void>;
+  shutdown(): Promise<void>;
+  consumer: KafkaConsumer & {
+    globalConfig: { rebalance_cb(err: number, assignment: unknown[]): void };
+    rebalanceProtocol(): string;
+    incrementalAssign(assignment: unknown[]): void;
+    incrementalUnassign(assignment: unknown[]): void;
+  };
+};
 
 const { ERR__REVOKE_PARTITIONS, ERR__ASSIGN_PARTITIONS } = Kafka.CODES.ERRORS;
 
@@ -10,7 +22,10 @@ const TOPIC = 'test-topic';
 
 const buildRunner = (sandbox: sinon.SinonSandbox, protocol = 'EAGER') => {
   const registry = {
-    getTask: () => ({ publish: () => {}, subscribe: sinon.stub().resolves() }),
+    getTask: () => ({
+      publish: sinon.stub(),
+      subscribe: sinon.stub().resolves(),
+    }),
     emit: sandbox.stub(),
     events: { emit: sandbox.stub() },
   };
@@ -22,11 +37,11 @@ const buildRunner = (sandbox: sinon.SinonSandbox, protocol = 'EAGER') => {
       batchProcessing: { enabled: true, batchSize: 10 },
     },
     registry,
-    // @ts-expect-error
+    // @ts-expect-error registry double only carries what the pool reads
     pool: build(registry),
   };
-  // @ts-expect-error
-  const runner: any = new Runner(steveo);
+  // @ts-expect-error steveo double only carries what the runner reads
+  const runner = new Runner(steveo) as unknown as TestRunner;
   sandbox.stub(runner.consumer, 'rebalanceProtocol').returns(protocol);
   sandbox.stub(runner.consumer, 'commitMessage');
   return runner;
@@ -41,8 +56,11 @@ const message = (partition: number, offset: number) => ({
 
 // driving globalConfig runs the client's own rebalance handling, so these
 // assertions cover our listener and the client's assign/unassign together
-const rebalance = (runner, code: number, assignment: unknown[] = []) =>
-  runner.consumer.globalConfig.rebalance_cb(code, assignment);
+const rebalance = (
+  runner: TestRunner,
+  code: number,
+  assignment: unknown[] = []
+) => runner.consumer.globalConfig.rebalance_cb(code, assignment);
 
 describe('runner/kafka - rebalance', () => {
   let sandbox: sinon.SinonSandbox;

--- a/packages/steveo/test/integration/kafka_batch_commit_test.ts
+++ b/packages/steveo/test/integration/kafka_batch_commit_test.ts
@@ -1,0 +1,164 @@
+import { expect } from 'chai';
+import { randomUUID } from 'crypto';
+import { promisify } from 'util';
+import logger from 'pino';
+import { KafkaConfiguration, Steveo } from '../../src';
+
+const sleep = promisify(setTimeout);
+
+const PARTITIONS = 3;
+const PER_PARTITION = 2;
+
+type Committed = { partition: number; offset?: number }[];
+
+const committedOffsets = (consumer, topic: string): Promise<Committed> => {
+  const toppars = Array.from({ length: PARTITIONS }, (_, partition) => ({
+    topic,
+    partition,
+  }));
+
+  return new Promise((resolve, reject) => {
+    consumer.committed(toppars, 5000, (err, result) =>
+      err ? reject(err) : resolve(result)
+    );
+  });
+};
+
+const waitFor = async (predicate: () => boolean, timeoutMs: number) => {
+  const deadline = Date.now() + timeoutMs;
+
+  while (!predicate() && Date.now() < deadline) {
+    // eslint-disable-next-line no-await-in-loop
+    await sleep(100);
+  }
+
+  return predicate();
+};
+
+describe('Kafka Integration Test - batch commit coverage', () => {
+  it('commits every partition the first batch drew from', async () => {
+    const topic = `steveo_batch_commit_${randomUUID().replace(/-/g, '')}`;
+    const total = PARTITIONS * PER_PARTITION;
+
+    const configuration: KafkaConfiguration = {
+      engine: 'kafka' as const,
+      shuffleQueue: false,
+      bootstrapServers: '0.0.0.0:9092',
+      defaultTopicPartitions: PARTITIONS,
+      defaultTopicReplicationFactor: 1,
+      tasksPath: '.',
+      securityProtocol: 'plaintext',
+      upperCaseNames: false,
+      middleware: [],
+      batchProcessing: { enabled: true, batchSize: total },
+      consumer: {
+        global: { 'group.id': `steveo-batch-commit-${randomUUID()}` },
+        topic: { 'auto.offset.reset': 'earliest' },
+      },
+      producer: { global: {}, topic: {} },
+    };
+
+    const steveo = new Steveo(configuration, logger({ level: 'warn' }));
+    const runner = steveo.runner() as any;
+
+    const handled: number[] = [];
+    let firstBatch: number[] | undefined;
+
+    steveo.task(topic, async (payload: { partition: number }) => {
+      handled.push(payload.partition);
+    });
+
+    // freeze after the first batch so no later batch can cover for it
+    steveo.events.on('batch_processed', () => {
+      if (!firstBatch) {
+        firstBatch = [...handled];
+        runner.state = 'paused';
+      }
+    });
+
+    await runner.createQueues();
+    await steveo.producer.initialize();
+
+    // explicit partitions, so the batch provably spans more than one of them
+    const { producer } = steveo.producer as any;
+    let delivered = 0;
+    const onDelivery = () => {
+      delivered += 1;
+    };
+
+    for (let partition = 0; partition < PARTITIONS; partition++) {
+      for (let i = 0; i < PER_PARTITION; i++) {
+        producer.produce(
+          topic,
+          partition,
+          Buffer.from(JSON.stringify({ partition, i })),
+          null,
+          Date.now(),
+          onDelivery
+        );
+      }
+    }
+
+    expect(
+      await waitFor(() => delivered === total, 20000),
+      `only ${delivered} of ${total} messages were delivered`
+    ).to.equal(true);
+
+    await steveo.start();
+
+    expect(
+      await waitFor(() => firstBatch !== undefined, 30000),
+      'no batch was processed'
+    ).to.equal(true);
+
+    const batch = firstBatch as number[];
+    const drawnFrom = [...new Set(batch)].sort();
+
+    expect(
+      drawnFrom.length,
+      `first batch only drew from partition ${drawnFrom}, so it cannot show the defect`
+    ).to.be.greaterThan(1);
+
+    // commitMessage is queued, so let librdkafka flush before reading back
+    const { consumer } = runner;
+    const expected = new Map(
+      drawnFrom.map(partition => [
+        partition,
+        batch.filter(p => p === partition).length,
+      ])
+    );
+
+    // a partition with no commit at all comes back without an offset field
+    const shortfall = (committed: Committed) =>
+      [...expected]
+        .map(([partition, count]) => {
+          const offset = committed.find(c => c.partition === partition)?.offset;
+          return typeof offset === 'number' && offset >= count
+            ? undefined
+            : `p${partition} committed ${
+                offset ?? 'nothing'
+              }, expected ${count}`;
+        })
+        .filter((entry): entry is string => entry !== undefined);
+
+    const deadline = Date.now() + 10000;
+    let committed: Committed = [];
+
+    do {
+      // eslint-disable-next-line no-await-in-loop
+      committed = await committedOffsets(consumer, topic);
+      if (shortfall(committed).length === 0) {
+        break;
+      }
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(200);
+    } while (Date.now() < deadline);
+
+    await steveo.stop();
+
+    expect(
+      shortfall(committed),
+      `first batch was ${JSON.stringify(batch)}`
+    ).to.eqls([]);
+  }).timeout(120000);
+});

--- a/packages/steveo/test/integration/kafka_batch_commit_test.ts
+++ b/packages/steveo/test/integration/kafka_batch_commit_test.ts
@@ -11,6 +11,23 @@ const PER_PARTITION = 2;
 
 type Committed = { partition: number; offset?: number }[];
 
+type TestRunner = {
+  createQueues(): Promise<unknown>;
+  state: string;
+  consumer: unknown;
+};
+
+type TestProducer = {
+  produce(
+    topic: string,
+    partition: number,
+    value: Buffer,
+    key: string | null,
+    timestamp: number,
+    callback: () => void
+  ): void;
+};
+
 const committedOffsets = (consumer, topic: string): Promise<Committed> => {
   const toppars = Array.from({ length: PARTITIONS }, (_, partition) => ({
     topic,
@@ -59,13 +76,14 @@ describe('Kafka Integration Test - batch commit coverage', () => {
     };
 
     const steveo = new Steveo(configuration, logger({ level: 'warn' }));
-    const runner = steveo.runner() as any;
+    const runner = steveo.runner() as unknown as TestRunner;
 
     const handled: number[] = [];
     let firstBatch: number[] | undefined;
 
-    steveo.task(topic, async (payload: { partition: number }) => {
+    steveo.task(topic, (payload: { partition: number }) => {
       handled.push(payload.partition);
+      return Promise.resolve();
     });
 
     // freeze after the first batch so no later batch can cover for it
@@ -80,7 +98,9 @@ describe('Kafka Integration Test - batch commit coverage', () => {
     await steveo.producer.initialize();
 
     // explicit partitions, so the batch provably spans more than one of them
-    const { producer } = steveo.producer as any;
+    const { producer } = steveo.producer as unknown as {
+      producer: TestProducer;
+    };
     let delivered = 0;
     const onDelivery = () => {
       delivered += 1;


### PR DESCRIPTION
## What's wrong

Two separate ways a Kafka consumer can lose track of where it got to.

**1. A batch only ever committed one partition.**

`consume(n)` pulls from the consumer's whole queue, so a single batch mixes messages from several partitions — and several topics. `processBatch` then committed exactly one message: the last one in the array. Every other partition in that batch kept its old committed offset.

```
batch: [p2/300, p2/301, p1/200, p0/100, p0/101]
                                        ^^^^^^ only this partition got committed
```

It self-heals under steady traffic, because the next batch usually ends on a different partition. The damage shows up on a restart or a rebalance: everything in the batch that wasn't the last message gets delivered again. Every existing batch test used `partition: 1` for every message, which is why nobody caught it.

**2. Nothing was committed when partitions were taken away.**

librdkafka flushes offsets for revoked partitions only when `enable.auto.commit` is on — steveo turns it off. Our `commitMessage` calls are queued, so any still in flight when the group generation bumps come back `ILLEGAL_GENERATION` and those messages are redelivered too.

## What changed

**Commit every partition the batch drew from**, at its highest processed offset, instead of just the last message.

**Hand assignment to the client** (`rebalance_cb: true`) and delete the 40-line callback steveo was carrying. The client's own handling is protocol-correct, which fixes a cooperative-rebalance bug we'd have hit if anyone re-enabled `cooperative-sticky`: our callback always called the full `assign`/`unassign`, dropping partitions the member still owned. It also emits `rebalance.error` on failure instead of calling `shutdown()`, so a transient assign failure no longer leaves a pod alive, silent, and consuming nothing with zero restarts.

**Flush before revoke.** A `rebalance` listener commits the offsets we've actually processed before the client releases the partitions. That event fires first, so the commit still lands in the old generation.

Worth calling out: it commits *processed* offsets, not librdkafka's stored ones. `enable.auto.offset.store` defaults to true and stores the offset of the last message **provided to the app** — with batching and concurrency that runs ahead of what's finished. Committing those would have skipped in-flight messages, which is worse than the redelivery this fixes.

Also gone: four error codes in the assign branch (`ERR_NOT_COORDINATOR_FOR_GROUP`, `ERR_REBALANCE_IN_PROGRESS`, `ERR_ILLEGAL_GENERATION`, `ERR_UNKNOWN_MEMBER_ID`) that can never arrive via `rebalance_cb` — they're poll-loop protocol errors.
