### PR TITLE
Node 26.x Upgrade Enablement

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,6 @@
 name: CI
-
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 on:
   workflow_dispatch:
   push:
@@ -16,10 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 18.x
+      - name: Setup Node.js
         uses: actions/setup-node@v4
-        with:
-          node-version: 18.x
       - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > ~/.npmrc
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
@@ -52,7 +51,7 @@ jobs:
           - 5432:5432
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 26.x]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,8 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
-      - name: Setup Node.js 22.x
+      - name: Setup Node
         uses: actions/setup-node@v4
-        with:
-          node-version: 22.x
 
       - name: Install latest npm
         run: npm install -g npm@11.10.0


### PR DESCRIPTION
Changes: 
- Disables Node builds for Node 18.x
- Enables Node builds for Node 26.x
- Re-enables Node builds for Node 20.x (which were running on 24.x) for compatibility validation